### PR TITLE
Yellow handheld shell with wide landscape LCD, faster physics, release APK CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build debug APK
+    name: Build release APK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,12 +25,12 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --stacktrace
+      - name: Build release APK
+        run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: escape-your-menahel-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: escape-your-menahel-release
+          path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ between you and the 4:15 bus to freedom.
 - **Rugelach collectibles**, score with time bonuses, 3 lives (displayed as
   black hats, naturally), and a persistent high score
 - **Pause = Mincha Break**
-- **ESCAPE BOY™ mode** — on touchscreen-only devices the game becomes a full
-  retro handheld: game screen in the LCD up top, d-pad + A/B + START on the
-  body below ("DOT MATRIX WITH MUSSAR"). Never shown when a physical
-  keypad/d-pad is present — keypad phones get the full screen
+- **ESCAPE BOY COLOR™ mode** — on touchscreen-only devices the game becomes
+  a full retro handheld in classic yellow: a wide landscape LCD up top,
+  d-pad + A/B + SELECT/START on the body below. The level re-flows into a
+  landscape world for the LCD. Never shown when a physical keypad/d-pad is
+  present — keypad phones keep the fullscreen portrait game
 
 ## Controls (keypad / d-pad)
 
@@ -43,12 +44,13 @@ shoots felafel, **START** pauses, and any tap confirms menus.
 ## Building
 
 ```bash
-./gradlew assembleDebug
+./gradlew assembleRelease
 ```
 
-The APK lands in `app/build/outputs/apk/debug/`. CI builds it automatically on
-every push (see `.github/workflows/android-ci.yml`) and uploads it as the
-`escape-your-menahel-debug` artifact.
+The APK lands in `app/build/outputs/apk/release/`. CI builds it automatically
+on every push (see `.github/workflows/android-ci.yml`) and uploads it as the
+`escape-your-menahel-release` artifact (signed with the debug key so it
+installs directly).
 
 ## Architecture
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,9 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt')
+            // Signed with the auto-generated debug key so CI produces an
+            // installable release APK without needing keystore secrets
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {

--- a/app/src/main/java/com/escapegame/GameView.kt
+++ b/app/src/main/java/com/escapegame/GameView.kt
@@ -151,7 +151,8 @@ class GameView(context: Context, private val engine: GameEngine) :
             TouchGamepadLayout.Control.DPAD_UP,
             TouchGamepadLayout.Control.BUTTON_B -> engine.onJump()
             TouchGamepadLayout.Control.BUTTON_A -> engine.onActionDown()
-            TouchGamepadLayout.Control.START -> engine.onPauseToggle()
+            TouchGamepadLayout.Control.START,
+            TouchGamepadLayout.Control.SELECT -> engine.onPauseToggle()
             else -> Unit
         }
     }

--- a/app/src/main/java/com/escapegame/core/GameConfig.kt
+++ b/app/src/main/java/com/escapegame/core/GameConfig.kt
@@ -15,20 +15,25 @@ object GameConfig {
     // Loop
     const val FRAME_MILLIS = 16L // ~60 FPS
 
-    // Virtual world (portrait)
+    // Virtual world. Keypad phones play fullscreen in the portrait world;
+    // touch mode plays in the landscape world shown inside the handheld
+    // shell's LCD. The portrait dimensions double as the shell's coordinate
+    // space. Levels are defined as fractions, so they re-flow to either.
     const val WORLD_WIDTH = 1080f
     const val WORLD_HEIGHT = 1920f
+    const val LANDSCAPE_WORLD_WIDTH = 1440f
+    const val LANDSCAPE_WORLD_HEIGHT = 1080f
 
     // World
-    const val FLOOR_HEIGHT = 180f
-    const val GRAVITY = 0.9f
+    const val FLOOR_TOP_FRACTION = 0.906f
+    const val GRAVITY = 1.6f
 
     // Player
     const val PLAYER_WIDTH = 60f
     const val PLAYER_HEIGHT = 75f
-    const val PLAYER_WALK_SPEED = 9f
-    const val PLAYER_RUN_SPEED = 16f
-    const val PLAYER_JUMP_POWER = -25f
+    const val PLAYER_WALK_SPEED = 11f
+    const val PLAYER_RUN_SPEED = 19f
+    const val PLAYER_JUMP_POWER = -33f
     const val PLAYER_FRICTION = 0.85f
     const val PLAYER_BASE_JUMPS = 2
     const val PLAYER_SELTZER_JUMPS = 3
@@ -46,7 +51,7 @@ object GameConfig {
     const val MENAHEL_STUN_FRAMES = 120
     const val MASHGIACH_WIDTH = 55f
     const val MASHGIACH_HEIGHT = 75f
-    const val MASHGIACH_SPEED = 3f
+    const val MASHGIACH_SPEED = 4f
     const val MASHGIACH_STUN_FRAMES = 150
     const val MENAHEL_CATCH_DISTANCE = 75f
     const val MASHGIACH_CATCH_DISTANCE = 65f
@@ -58,7 +63,7 @@ object GameConfig {
 
     // Projectiles
     const val FELAFEL_COOLDOWN_MILLIS = 300L
-    const val FELAFEL_SPEED = 16f
+    const val FELAFEL_SPEED = 20f
     const val FELAFEL_RADIUS = 12f
 
     // Scoring

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -36,11 +36,11 @@ import kotlin.random.Random
  */
 class GameEngine(private val highScores: HighScoreStore) {
 
-    private val worldWidth = GameConfig.WORLD_WIDTH
-    private val worldHeight = GameConfig.WORLD_HEIGHT
-    private val floorTop = worldHeight - GameConfig.FLOOR_HEIGHT
+    private var worldWidth = GameConfig.WORLD_WIDTH
+    private var worldHeight = GameConfig.WORLD_HEIGHT
+    private var floorTop = worldHeight * GameConfig.FLOOR_TOP_FRACTION
+    private var doorLeft = worldWidth - GameConfig.DOOR_WIDTH - 30f
     private val playerStartX = 40f
-    private val doorLeft = worldWidth - GameConfig.DOOR_WIDTH - 30f
 
     var phase = GamePhase.INTRO
         private set
@@ -68,16 +68,28 @@ class GameEngine(private val highScores: HighScoreStore) {
     private var rightPressed = false
     private var runPressed = false
 
+    init {
+        // Populate level 1 so the intro screen has a real backdrop
+        buildLevel(0)
+    }
+
     /**
-     * True when the on-screen Game Boy-style gamepad should be shown: set by
-     * the view when the device has no physical keypad/d-pad or the player
-     * touches the screen; cleared again the moment a physical key is used.
+     * True when the handheld-shell presentation should be used: set by the
+     * view when the device has no physical keypad/d-pad or the player touches
+     * the screen; cleared again the moment a physical key is used. Touch mode
+     * plays in the landscape world inside the shell's LCD; keypad mode plays
+     * the portrait world fullscreen.
      */
     var touchControlsEnabled = false
+        set(value) {
+            if (field == value) return
+            field = value
+            applyWorldSize()
+        }
 
-    private val background = BackgroundRenderer()
-    private val hud = HudRenderer()
-    private val overlay = OverlayRenderer()
+    private var background = BackgroundRenderer(worldWidth, worldHeight)
+    private var hud = HudRenderer(worldWidth)
+    private var overlay = OverlayRenderer(worldWidth, worldHeight)
     private val gamepad = TouchGamepadRenderer()
     private val shell = GameBoyShellRenderer()
     private val floatingTextPaint = Paint().apply {
@@ -154,7 +166,37 @@ class GameEngine(private val highScores: HighScoreStore) {
         phaseFrames = 0
     }
 
+    /**
+     * Switches between the portrait and landscape worlds and re-flows the
+     * current level into it (levels are fraction-based, so the layout
+     * adapts). Mid-run the player gets the level card again as a beat.
+     */
+    private fun applyWorldSize() {
+        if (touchControlsEnabled) {
+            worldWidth = GameConfig.LANDSCAPE_WORLD_WIDTH
+            worldHeight = GameConfig.LANDSCAPE_WORLD_HEIGHT
+        } else {
+            worldWidth = GameConfig.WORLD_WIDTH
+            worldHeight = GameConfig.WORLD_HEIGHT
+        }
+        floorTop = worldHeight * GameConfig.FLOOR_TOP_FRACTION
+        doorLeft = worldWidth - GameConfig.DOOR_WIDTH - 30f
+        background = BackgroundRenderer(worldWidth, worldHeight)
+        hud = HudRenderer(worldWidth)
+        overlay = OverlayRenderer(worldWidth, worldHeight)
+        buildLevel(levelIndex)
+        if (phase == GamePhase.PLAYING || phase == GamePhase.PAUSED) {
+            phase = GamePhase.LEVEL_INTRO
+            phaseFrames = 0
+        }
+    }
+
     private fun loadLevel(index: Int) {
+        buildLevel(index)
+        phase = GamePhase.LEVEL_INTRO
+    }
+
+    private fun buildLevel(index: Int) {
         levelIndex = index
         level = Levels.all[index]
 
@@ -198,7 +240,6 @@ class GameEngine(private val highScores: HighScoreStore) {
 
         levelFrames = 0
         phaseFrames = 0
-        phase = GamePhase.LEVEL_INTRO
     }
 
     private fun beginPlay() {
@@ -392,7 +433,13 @@ class GameEngine(private val highScores: HighScoreStore) {
     /** Scales the virtual world onto the actual surface and draws everything. */
     fun draw(canvas: Canvas, viewWidth: Int, viewHeight: Int) {
         canvas.save()
-        canvas.scale(viewWidth / worldWidth, viewHeight / worldHeight)
+        // Outer transform maps the shell/portrait space to the surface; in
+        // keypad mode the world IS that space, in touch mode the landscape
+        // world is placed inside the shell's LCD below.
+        canvas.scale(
+            viewWidth / GameConfig.WORLD_WIDTH,
+            viewHeight / GameConfig.WORLD_HEIGHT
+        )
 
         if (touchControlsEnabled) {
             // Full handheld-console look: shell around the LCD, game inside

--- a/app/src/main/java/com/escapegame/entities/Talmid.kt
+++ b/app/src/main/java/com/escapegame/entities/Talmid.kt
@@ -107,13 +107,13 @@ class Talmid {
     fun moveLeft(isRunning: Boolean) {
         running = isRunning
         facingRight = false
-        velocityX = kotlin.math.max(velocityX - 1.5f, -currentSpeed(isRunning))
+        velocityX = kotlin.math.max(velocityX - 2.2f, -currentSpeed(isRunning))
     }
 
     fun moveRight(isRunning: Boolean) {
         running = isRunning
         facingRight = true
-        velocityX = kotlin.math.min(velocityX + 1.5f, currentSpeed(isRunning))
+        velocityX = kotlin.math.min(velocityX + 2.2f, currentSpeed(isRunning))
     }
 
     fun stopMoving() {

--- a/app/src/main/java/com/escapegame/levels/Levels.kt
+++ b/app/src/main/java/com/escapegame/levels/Levels.kt
@@ -34,7 +34,7 @@ object Levels {
             name = "The Lunchroom",
             quip = "Fleishig day. The Menahel spotted your untucked shirt at bentching.",
             theme = LevelTheme.LUNCHROOM,
-            menahelSpeed = 2.6f,
+            menahelSpeed = 3.1f,
             platforms = listOf(
                 PlatformSpec(0.12f, T1, 0.24f),
                 PlatformSpec(0.45f, T2, 0.24f),
@@ -51,7 +51,7 @@ object Levels {
             name = "Hallway of the Hanhala",
             quip = "The sign says NO RUNNING IN THE HALLWAY. Nu, so run quietly.",
             theme = LevelTheme.HALLWAY,
-            menahelSpeed = 2.85f,
+            menahelSpeed = 3.4f,
             platforms = listOf(
                 PlatformSpec(0.08f, T1, 0.20f),
                 PlatformSpec(0.38f, T2, 0.22f),
@@ -72,7 +72,7 @@ object Levels {
             name = "The Great Cholent Spill",
             quip = "Erev Shabbos. The cholent reached yad soledes bo. So did the floor.",
             theme = LevelTheme.KITCHEN,
-            menahelSpeed = 3.1f,
+            menahelSpeed = 3.7f,
             platforms = listOf(
                 PlatformSpec(0.15f, T1, 0.22f),
                 PlatformSpec(0.50f, T1, 0.22f),
@@ -94,7 +94,7 @@ object Levels {
             name = "Shiur Room 3B",
             quip = "The Rebbi stepped out for a minute. The Menahel stepped in. And the Mashgiach.",
             theme = LevelTheme.CLASSROOM,
-            menahelSpeed = 3.3f,
+            menahelSpeed = 4.0f,
             platforms = listOf(
                 PlatformSpec(0.10f, T1, 0.22f),
                 PlatformSpec(0.42f, T2, 0.24f),
@@ -118,7 +118,7 @@ object Levels {
             name = "The Beis Medrash",
             quip = "Quiet please. Escaping b'iyun in progress.",
             theme = LevelTheme.BEIS_MEDRASH,
-            menahelSpeed = 3.5f,
+            menahelSpeed = 4.3f,
             platforms = listOf(
                 PlatformSpec(0.08f, T1, 0.20f),
                 PlatformSpec(0.36f, T2, 0.20f),
@@ -142,7 +142,7 @@ object Levels {
             name = "The Gym (Social Hall)",
             quip = "Folding chairs from last night's vort everywhere. The Menahel ran track in '87. Allegedly.",
             theme = LevelTheme.GYM,
-            menahelSpeed = 3.75f,
+            menahelSpeed = 4.6f,
             platforms = listOf(
                 PlatformSpec(0.12f, T1, 0.18f),
                 PlatformSpec(0.44f, T1, 0.18f),
@@ -170,7 +170,7 @@ object Levels {
             name = "The Otzar HaSeforim",
             quip = "SHHHH. (Also: run.)",
             theme = LevelTheme.LIBRARY,
-            menahelSpeed = 4.0f,
+            menahelSpeed = 4.9f,
             platforms = listOf(
                 PlatformSpec(0.10f, T1, 0.18f),
                 PlatformSpec(0.38f, T2, 0.18f),
@@ -194,7 +194,7 @@ object Levels {
             name = "The Kitchen",
             quip = "Fresh felafel. Unlimited ammo. B'dieved, also lunch.",
             theme = LevelTheme.KITCHEN,
-            menahelSpeed = 4.25f,
+            menahelSpeed = 5.2f,
             platforms = listOf(
                 PlatformSpec(0.14f, T1, 0.20f),
                 PlatformSpec(0.48f, T2, 0.20f),
@@ -221,7 +221,7 @@ object Levels {
             name = "Detention Row",
             quip = "No one has ever escaped detention. Be the first. B'ezras Hashem.",
             theme = LevelTheme.DETENTION,
-            menahelSpeed = 4.5f,
+            menahelSpeed = 5.5f,
             platforms = listOf(
                 PlatformSpec(0.06f, T1, 0.16f),
                 PlatformSpec(0.32f, T1, 0.16f),
@@ -251,7 +251,7 @@ object Levels {
             name = "The Roof (Assur!)",
             quip = "You are absolutely not allowed up here. That's the whole point.",
             theme = LevelTheme.ROOFTOP,
-            menahelSpeed = 4.75f,
+            menahelSpeed = 5.8f,
             platforms = listOf(
                 PlatformSpec(0.10f, T1, 0.18f),
                 PlatformSpec(0.40f, T2, 0.18f),
@@ -278,7 +278,7 @@ object Levels {
             name = "The Parking Lot",
             quip = "The Menahel's minivan has 340,000 miles and the koach of a lion.",
             theme = LevelTheme.PARKING_LOT,
-            menahelSpeed = 5.0f,
+            menahelSpeed = 6.1f,
             platforms = listOf(
                 PlatformSpec(0.08f, T1, 0.16f),
                 PlatformSpec(0.34f, T2, 0.16f),
@@ -308,7 +308,7 @@ object Levels {
             name = "The 4:15 Bus",
             quip = "The bus to freedom is at the corner. The Menahel is faster than he looks. NU, RUN!",
             theme = LevelTheme.BUS_STOP,
-            menahelSpeed = 5.4f,
+            menahelSpeed = 6.6f,
             platforms = listOf(
                 PlatformSpec(0.06f, T1, 0.15f),
                 PlatformSpec(0.30f, T2, 0.15f),

--- a/app/src/main/java/com/escapegame/render/BackgroundRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/BackgroundRenderer.kt
@@ -10,13 +10,12 @@ import com.escapegame.model.Platform
 
 /**
  * Draws the per-theme scenery, the platforms, and the exit door.
- * Everything is drawn in virtual world coordinates.
+ * Everything is drawn in virtual world coordinates; construct with the
+ * active world's dimensions (portrait fullscreen or landscape LCD).
  */
-class BackgroundRenderer {
+class BackgroundRenderer(private val w: Float, private val h: Float) {
 
-    private val w = GameConfig.WORLD_WIDTH
-    private val h = GameConfig.WORLD_HEIGHT
-    private val floorTop = h - GameConfig.FLOOR_HEIGHT
+    private val floorTop = h * GameConfig.FLOOR_TOP_FRACTION
 
     private val fillPaint = Paint().apply { style = Paint.Style.FILL }
     private val strokePaint = Paint().apply { style = Paint.Style.STROKE; strokeWidth = 3f }

--- a/app/src/main/java/com/escapegame/render/GameBoyShell.kt
+++ b/app/src/main/java/com/escapegame/render/GameBoyShell.kt
@@ -3,13 +3,14 @@ package com.escapegame.render
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.RectF
 import android.graphics.Typeface
 import com.escapegame.core.GameConfig
 
 /**
- * Draws the classic handheld-console shell used in touch mode: gray body,
- * dark screen bezel with the obligatory accent stripes, a power LED, a
- * speaker grille, and period-correct labeling ("DOT MATRIX WITH MUSSAR").
+ * Draws the handheld-console shell used in touch mode, styled after the
+ * classic yellow color handheld: yellow body, minimal dark bezel around a
+ * wide landscape LCD, multicolor logo, power LED, dotted speaker grille.
  * The actual game renders inside [TouchGamepadLayout.screenLcd] on top.
  */
 class GameBoyShellRenderer {
@@ -17,81 +18,104 @@ class GameBoyShellRenderer {
     private val w = GameConfig.WORLD_WIDTH
     private val h = GameConfig.WORLD_HEIGHT
 
-    private val bodyPaint = Paint().apply { color = Color.rgb(196, 196, 204); style = Paint.Style.FILL }
-    private val bezelPaint = Paint().apply { color = Color.rgb(45, 45, 58); style = Paint.Style.FILL }
+    private val bodyPaint = Paint().apply { color = Color.rgb(248, 200, 40); style = Paint.Style.FILL }
+    private val bodyShadePaint = Paint().apply { color = Color.rgb(226, 176, 24); style = Paint.Style.FILL }
+    private val bezelPaint = Paint().apply { color = Color.rgb(24, 24, 34); style = Paint.Style.FILL }
     private val lcdOffPaint = Paint().apply { color = Color.rgb(52, 62, 52); style = Paint.Style.FILL }
-    private val stripeMaroon = Paint().apply {
-        color = Color.rgb(140, 30, 50)
-        strokeWidth = 8f
+    private val ledPaint = Paint().apply { color = Color.rgb(235, 45, 45); style = Paint.Style.FILL }
+    private val ledLabelPaint = Paint().apply {
+        color = Color.rgb(200, 200, 210)
+        textSize = 19f
+        textAlign = Paint.Align.LEFT
+    }
+    private val logoPaint = Paint().apply {
+        textSize = 44f
+        textAlign = Paint.Align.LEFT
+        typeface = Typeface.create(Typeface.DEFAULT_BOLD, Typeface.BOLD_ITALIC)
+    }
+    private val pillOutlinePaint = Paint().apply {
+        color = Color.rgb(170, 130, 15)
+        strokeWidth = 4f
         style = Paint.Style.STROKE
     }
-    private val stripeNavy = Paint().apply {
-        color = Color.rgb(40, 50, 120)
-        strokeWidth = 8f
-        style = Paint.Style.STROKE
-    }
-    private val bezelTextPaint = Paint().apply {
-        color = Color.rgb(210, 210, 220)
+    private val pillTextPaint = Paint().apply {
+        color = Color.rgb(140, 105, 12)
         textSize = 24f
         textAlign = Paint.Align.CENTER
     }
-    private val ledPaint = Paint().apply { color = Color.rgb(230, 40, 40); style = Paint.Style.FILL }
-    private val ledLabelPaint = Paint().apply {
-        color = Color.rgb(200, 200, 210)
-        textSize = 17f
-        textAlign = Paint.Align.CENTER
-    }
-    private val logoPaint = Paint().apply {
-        color = Color.rgb(215, 215, 225)
-        textSize = 36f
-        textAlign = Paint.Align.CENTER
-        typeface = Typeface.create(Typeface.DEFAULT_BOLD, Typeface.BOLD_ITALIC)
-    }
     private val bodyLabelPaint = Paint().apply {
-        color = Color.rgb(120, 120, 132)
+        color = Color.rgb(160, 122, 14)
         textSize = 20f
         textAlign = Paint.Align.CENTER
     }
-    private val speakerPaint = Paint().apply {
-        color = Color.rgb(150, 150, 162)
-        strokeWidth = 13f
-        strokeCap = Paint.Cap.ROUND
-        style = Paint.Style.STROKE
-    }
+    private val speakerPaint = Paint().apply { color = Color.rgb(120, 92, 12); style = Paint.Style.FILL }
+    private val hanhalaRect = RectF(450f, 948f, 630f, 1000f)
+
+    // "COLOR" gets one color per letter, like the original logo
+    private val colorLetterColors = intArrayOf(
+        Color.rgb(235, 60, 60),
+        Color.rgb(250, 170, 40),
+        Color.rgb(90, 190, 80),
+        Color.rgb(70, 130, 230),
+        Color.rgb(170, 90, 200)
+    )
 
     fun draw(canvas: Canvas) {
-        // Body
+        // Body with a subtly shaded lower edge
         canvas.drawRect(0f, 0f, w, h, bodyPaint)
+        canvas.drawRect(0f, h - 40f, w, h, bodyShadePaint)
 
-        // Screen bezel with accent stripes flanking the slogan
-        canvas.drawRoundRect(TouchGamepadLayout.screenBezel, 40f, 40f, bezelPaint)
-        val stripeY1 = 92f
-        val stripeY2 = 112f
-        canvas.drawLine(110f, stripeY1, 300f, stripeY1, stripeMaroon)
-        canvas.drawLine(110f, stripeY2, 300f, stripeY2, stripeNavy)
-        canvas.drawLine(780f, stripeY1, 970f, stripeY1, stripeMaroon)
-        canvas.drawLine(780f, stripeY2, 970f, stripeY2, stripeNavy)
-        canvas.drawText("DOT MATRIX WITH MUSSAR", w / 2, 112f, bezelTextPaint)
+        // Minimal bezel around the wide landscape LCD
+        canvas.drawRoundRect(TouchGamepadLayout.screenBezel, 36f, 36f, bezelPaint)
 
-        // LCD backing (visible as pillarbox bars around the game)
+        // Power LED in the bezel's top strip
+        canvas.drawCircle(80f, 96f, 9f, ledPaint)
+        canvas.drawText("SHTEIG", 100f, 103f, ledLabelPaint)
+
+        // LCD backing behind the game
         canvas.drawRect(TouchGamepadLayout.screenLcd, lcdOffPaint)
 
-        // Power LED: lights up when you're shteiging (always)
-        canvas.drawCircle(104f, 700f, 10f, ledPaint)
-        canvas.drawText("SHTEIG", 104f, 736f, ledLabelPaint)
-
-        // Logo strip under the LCD
-        canvas.drawText("ESCAPE BOY™", w / 2, 1364f, logoPaint)
-
-        // Body label under the START pill
-        canvas.drawText("KOSHER VIDEO GAME SYSTEM · EST. 5747", w / 2, 1906f, bodyLabelPaint)
-
-        // Speaker grille, bottom-right
-        var i = 0
-        while (i < 6) {
-            val x = 830f + i * 30f
-            canvas.drawLine(x, 1878f, x + 62f, 1792f, speakerPaint)
-            i++
+        // Logo strip under the LCD: "ESCAPE BOY" white, "COLOR" multicolored
+        val logoY = 872f
+        val part1 = "ESCAPE BOY "
+        val colorWord = "COLOR"
+        val part1Width = logoPaint.measureText(part1)
+        var letterX = 0f
+        val letterWidths = FloatArray(colorWord.length)
+        var colorWidth = 0f
+        for (i in colorWord.indices) {
+            letterWidths[i] = logoPaint.measureText(colorWord, i, i + 1)
+            colorWidth += letterWidths[i]
         }
+        var x = (w - part1Width - colorWidth) / 2
+        logoPaint.color = Color.rgb(230, 230, 240)
+        canvas.drawText(part1, x, logoY, logoPaint)
+        x += part1Width
+        for (i in colorWord.indices) {
+            logoPaint.color = colorLetterColors[i % colorLetterColors.size]
+            canvas.drawText(colorWord, i, i + 1, x + letterX, logoY, logoPaint)
+            letterX += letterWidths[i]
+        }
+
+        // The oval maker's mark on the body
+        canvas.drawRoundRect(hanhalaRect, 26f, 26f, pillOutlinePaint)
+        canvas.drawText("HANHALA®", hanhalaRect.centerX(), hanhalaRect.centerY() + 9f, pillTextPaint)
+
+        // Dotted speaker grille, bottom-right diamond
+        var row = 0
+        while (row < 6) {
+            var col = 0
+            while (col < 5) {
+                // Trim corners for the classic diamond-ish grille shape
+                val corner = (row == 0 || row == 5) && (col == 0 || col == 4)
+                if (!corner) {
+                    canvas.drawCircle(818f + col * 40f, 1660f + row * 40f, 9f, speakerPaint)
+                }
+                col++
+            }
+            row++
+        }
+
+        canvas.drawText("KOSHER VIDEO GAME SYSTEM · EST. 5747", w / 2, 1878f, bodyLabelPaint)
     }
 }

--- a/app/src/main/java/com/escapegame/render/HudRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/HudRenderer.kt
@@ -3,7 +3,6 @@ package com.escapegame.render
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
-import com.escapegame.core.GameConfig
 import com.escapegame.entities.Talmid
 import com.escapegame.model.LevelDefinition
 
@@ -11,9 +10,7 @@ import com.escapegame.model.LevelDefinition
  * In-game heads-up display: score, high score, level name, remaining lives
  * (drawn as little black hats, naturally), and active power-up timers.
  */
-class HudRenderer {
-
-    private val w = GameConfig.WORLD_WIDTH
+class HudRenderer(private val w: Float) {
 
     private val textPaint = Paint().apply {
         color = Color.BLACK

--- a/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
@@ -5,22 +5,22 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
-import com.escapegame.core.GameConfig
 import com.escapegame.levels.Levels
 import com.escapegame.model.LevelDefinition
 
 /**
  * Full-screen overlay states: title screen, level intro cards, pause
- * ("mincha break"), game over, and victory. All d-pad driven: CENTER/5/OK is
- * always the confirm button.
+ * ("mincha break"), game over, and victory. Construct with the active
+ * world's dimensions; landscape (LCD) worlds get a tighter layout.
+ * CENTER/5/OK — or any tap in touch mode — is always the confirm button.
  */
-class OverlayRenderer {
+class OverlayRenderer(private val w: Float, private val h: Float) {
 
     /** When true, prompts say "tap" instead of naming keypad keys. */
     var touchMode = false
 
-    private val w = GameConfig.WORLD_WIDTH
-    private val h = GameConfig.WORLD_HEIGHT
+    /** Landscape LCD world: less vertical room, so trim the layout. */
+    private val compact = w > h
 
     private val dimPaint = Paint().apply { color = Color.argb(205, 0, 0, 0); style = Paint.Style.FILL }
     private val cardPaint = Paint().apply { color = Color.argb(235, 25, 25, 35); style = Paint.Style.FILL }
@@ -68,6 +68,24 @@ class OverlayRenderer {
     fun drawIntro(canvas: Canvas, highScore: Int) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
 
+        if (compact) {
+            canvas.drawText("ESCAPE YOUR MENAHEL!", w / 2, h * 0.16f, titlePaint)
+            canvas.drawText("You left the beis medrash early. He saw.", w / 2, h * 0.27f, bodyPaint)
+
+            var y = h * 0.40f
+            val lh = 46f
+            canvas.drawText("D-pad — move  ·  B — jump (x2 = double)", w / 2, y, bodyPaint); y += lh
+            canvas.drawText("A — run + shoot felafel", w / 2, y, bodyPaint); y += lh
+            canvas.drawText("START — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.4f
+            canvas.drawText("Grab rugelach. 12 levels to the 4:15 bus.", w / 2, y, bodyPaint)
+
+            if (highScore > 0) {
+                canvas.drawText("Best escape so far: $highScore", w / 2, h * 0.76f, bodyPaint)
+            }
+            canvas.drawText(confirmPrompt("start"), w / 2, h * 0.87f, accentPaint)
+            return
+        }
+
         canvas.drawText("ESCAPE YOUR", w / 2, h * 0.13f, titlePaint)
         canvas.drawText("MENAHEL!", w / 2, h * 0.18f, titlePaint)
         canvas.drawText("The Yeshiva Breakout", w / 2, h * 0.225f, bodyPaint)
@@ -77,19 +95,11 @@ class OverlayRenderer {
         canvas.drawText("You left the beis medrash early.", w / 2, y, bodyPaint); y += lh
         canvas.drawText("He saw. He ALWAYS sees.", w / 2, y, bodyPaint); y += lh * 1.8f
 
-        if (touchMode) {
-            canvas.drawText("TOUCH CONTROLS", w / 2, y, accentPaint); y += lh * 1.2f
-            canvas.drawText("D-pad — move · ▲ — jump", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("B — jump (twice = double jump)", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("A — run + shoot felafel", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("START — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.8f
-        } else {
-            canvas.drawText("KEYPAD / D-PAD CONTROLS", w / 2, y, accentPaint); y += lh * 1.2f
-            canvas.drawText("4 / 6  or  LEFT / RIGHT — move", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("2  or  UP — jump (twice = double jump)", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("5  or  OK — run + shoot felafel", w / 2, y, bodyPaint); y += lh
-            canvas.drawText("P / MENU — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.8f
-        }
+        canvas.drawText("KEYPAD / D-PAD CONTROLS", w / 2, y, accentPaint); y += lh * 1.2f
+        canvas.drawText("4 / 6  or  LEFT / RIGHT — move", w / 2, y, bodyPaint); y += lh
+        canvas.drawText("2  or  UP — jump (twice = double jump)", w / 2, y, bodyPaint); y += lh
+        canvas.drawText("5  or  OK — run + shoot felafel", w / 2, y, bodyPaint); y += lh
+        canvas.drawText("P / MENU — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.8f
 
         canvas.drawText("Grab rugelach. Chap the power-ups.", w / 2, y, bodyPaint); y += lh
         canvas.drawText("12 levels between you and the 4:15 bus.", w / 2, y, bodyPaint); y += lh * 1.6f
@@ -104,14 +114,20 @@ class OverlayRenderer {
 
     fun drawLevelIntro(canvas: Canvas, level: LevelDefinition) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
-        cardRect.set(w * 0.08f, h * 0.32f, w * 0.92f, h * 0.62f)
+        if (compact) {
+            cardRect.set(w * 0.12f, h * 0.24f, w * 0.88f, h * 0.76f)
+        } else {
+            cardRect.set(w * 0.08f, h * 0.32f, w * 0.92f, h * 0.62f)
+        }
         canvas.drawRoundRect(cardRect, 24f, 24f, cardPaint)
         canvas.drawRoundRect(cardRect, 24f, 24f, cardStrokePaint)
 
-        canvas.drawText("Level ${level.number} of ${Levels.all.size}", w / 2, h * 0.385f, bodyPaint)
-        canvas.drawText(level.name, w / 2, h * 0.44f, headerPaint)
-        drawWrapped(canvas, level.quip, w / 2, h * 0.50f, w * 0.72f)
-        canvas.drawText(confirmPrompt("go"), w / 2, h * 0.595f, accentPaint)
+        val top = cardRect.top
+        val height = cardRect.height()
+        canvas.drawText("Level ${level.number} of ${Levels.all.size}", w / 2, top + height * 0.18f, bodyPaint)
+        canvas.drawText(level.name, w / 2, top + height * 0.36f, headerPaint)
+        drawWrapped(canvas, level.quip, w / 2, top + height * 0.55f, cardRect.width() * 0.86f)
+        canvas.drawText(confirmPrompt("go"), w / 2, cardRect.bottom - height * 0.1f, accentPaint)
     }
 
     fun drawPaused(canvas: Canvas) {
@@ -123,38 +139,41 @@ class OverlayRenderer {
 
     fun drawGameOver(canvas: Canvas, line: String, score: Int, highScore: Int, isNewBest: Boolean) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
-        canvas.drawText("CAUGHT!", w / 2, h * 0.35f, redPaint)
+        canvas.drawText("CAUGHT!", w / 2, h * 0.32f, redPaint)
         drawWrapped(canvas, line, w / 2, h * 0.42f, w * 0.8f)
-        canvas.drawText("Score: $score", w / 2, h * 0.52f, bodyPaint)
+        canvas.drawText("Score: $score", w / 2, h * 0.55f, bodyPaint)
         if (isNewBest) {
-            canvas.drawText("NEW RECORD! Mamash a kiddush!", w / 2, h * 0.565f, accentPaint)
+            canvas.drawText("NEW RECORD! Mamash a kiddush!", w / 2, h * 0.61f, accentPaint)
         } else {
-            canvas.drawText("Best: $highScore", w / 2, h * 0.565f, bodyPaint)
+            canvas.drawText("Best: $highScore", w / 2, h * 0.61f, bodyPaint)
         }
-        canvas.drawText(confirmPrompt("try again"), w / 2, h * 0.66f, accentPaint)
+        canvas.drawText(confirmPrompt("try again"), w / 2, h * 0.72f, accentPaint)
     }
 
     fun drawVictory(canvas: Canvas, score: Int, highScore: Int, isNewBest: Boolean) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
-        canvas.drawText("BARUCH", w / 2, h * 0.24f, titlePaint)
-        canvas.drawText("SHEPTARANI!", w / 2, h * 0.29f, titlePaint)
+        if (compact) {
+            canvas.drawText("BARUCH SHEPTARANI!", w / 2, h * 0.2f, titlePaint)
+        } else {
+            canvas.drawText("BARUCH", w / 2, h * 0.16f, titlePaint)
+            canvas.drawText("SHEPTARANI!", w / 2, h * 0.21f, titlePaint)
+        }
 
-        var y = h * 0.38f
+        var y = h * 0.32f
+        val lh = if (compact) 46f else 52f
         for (line in Levels.victoryLines) {
             canvas.drawText(line, w / 2, y, bodyPaint)
-            y += 52f
+            y += lh
         }
 
-        y += 30f
-        canvas.drawText("Final score: $score", w / 2, y, headerPaint)
-        y += 60f
+        canvas.drawText("Final score: $score", w / 2, h * 0.62f, headerPaint)
         if (isNewBest) {
-            canvas.drawText("NEW RECORD! Tell your chavrusa!", w / 2, y, accentPaint)
+            canvas.drawText("NEW RECORD! Tell your chavrusa!", w / 2, h * 0.69f, accentPaint)
         } else {
-            canvas.drawText("Best: $highScore", w / 2, y, bodyPaint)
+            canvas.drawText("Best: $highScore", w / 2, h * 0.69f, bodyPaint)
         }
 
-        canvas.drawText(confirmPrompt("start another zman"), w / 2, h * 0.75f, accentPaint)
+        canvas.drawText(confirmPrompt("start another zman"), w / 2, h * 0.8f, accentPaint)
     }
 
     /** "Press 5 / OK to X" on keypads, "Tap to X" on touchscreens. */

--- a/app/src/main/java/com/escapegame/render/TouchGamepad.kt
+++ b/app/src/main/java/com/escapegame/render/TouchGamepad.kt
@@ -6,53 +6,51 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.Typeface
+import com.escapegame.core.GameConfig
 
 /**
- * Game Boy-style on-screen gamepad for touchscreen-only devices: a cross
- * d-pad bottom-left, diagonal B/A buttons bottom-right, and a START pill for
- * pause. Never shown on devices with a physical keypad/d-pad — [hit] and the
- * renderer are only used once the view enables touch mode.
+ * Handheld-console control layout for touchscreen-only devices: a cross
+ * d-pad bottom-left, diagonal B/A buttons bottom-right, SELECT/START pills,
+ * with the game's landscape LCD up top. Never shown on devices with a
+ * physical keypad/d-pad.
  *
- * All geometry is in virtual world coordinates so the pad scales with the
- * rest of the game.
+ * All geometry is in shell coordinates (the portrait 1080x1920 space).
  */
 object TouchGamepadLayout {
 
-    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, BUTTON_A, BUTTON_B, START, NONE }
+    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, BUTTON_A, BUTTON_B, START, SELECT, NONE }
 
-    // Handheld-shell geometry: the game renders inside the "LCD" up top,
-    // the controls live on the body below it.
-    val screenBezel = RectF(70f, 50f, 1010f, 1380f)
-    val screenLcd = RectF(140f, 150f, 940f, 1330f)
+    // Shell geometry: a wide, minimal bezel around a 4:3 landscape LCD;
+    // the game world (1440x1080) fits it exactly.
+    val screenBezel = RectF(40f, 70f, 1040f, 920f)
+    val screenLcd = RectF(90f, 120f, 990f, 795f)
 
-    /** Uniform scale that fits the virtual world inside the LCD. */
+    /** Uniform scale that fits the landscape world inside the LCD. */
     val screenScale: Float = kotlin.math.min(
-        screenLcd.width() / com.escapegame.core.GameConfig.WORLD_WIDTH,
-        screenLcd.height() / com.escapegame.core.GameConfig.WORLD_HEIGHT
+        screenLcd.width() / GameConfig.LANDSCAPE_WORLD_WIDTH,
+        screenLcd.height() / GameConfig.LANDSCAPE_WORLD_HEIGHT
     )
     val screenOffsetX: Float =
-        screenLcd.left + (screenLcd.width() - com.escapegame.core.GameConfig.WORLD_WIDTH * screenScale) / 2
+        screenLcd.left + (screenLcd.width() - GameConfig.LANDSCAPE_WORLD_WIDTH * screenScale) / 2
     val screenOffsetY: Float =
-        screenLcd.top + (screenLcd.height() - com.escapegame.core.GameConfig.WORLD_HEIGHT * screenScale) / 2
+        screenLcd.top + (screenLcd.height() - GameConfig.LANDSCAPE_WORLD_HEIGHT * screenScale) / 2
 
     // D-pad cross
-    const val DPAD_CX = 215f
-    const val DPAD_CY = 1600f
-    const val DPAD_ARM = 175f
-    const val DPAD_THICK = 115f
+    const val DPAD_CX = 235f
+    const val DPAD_CY = 1235f
+    const val DPAD_ARM = 165f
+    const val DPAD_THICK = 110f
 
-    // Buttons (Game Boy diagonal: A upper-right of B)
-    const val A_CX = 935f
-    const val A_CY = 1520f
-    const val B_CX = 715f
-    const val B_CY = 1660f
-    const val BUTTON_RADIUS = 95f
+    // Buttons (diagonal: A upper-right of B)
+    const val A_CX = 900f
+    const val A_CY = 1200f
+    const val B_CX = 660f
+    const val B_CY = 1310f
+    const val BUTTON_RADIUS = 92f
 
-    // START pill
-    const val START_LEFT = 440f
-    const val START_TOP = 1810f
-    const val START_RIGHT = 640f
-    const val START_BOTTOM = 1870f
+    // SELECT / START pills
+    val selectRect = RectF(350f, 1520f, 520f, 1578f)
+    val startRect = RectF(560f, 1520f, 730f, 1578f)
 
     fun hit(x: Float, y: Float): Control {
         var dx = x - A_CX
@@ -61,7 +59,8 @@ object TouchGamepadLayout {
         dx = x - B_CX
         dy = y - B_CY
         if (dx * dx + dy * dy <= BUTTON_RADIUS * BUTTON_RADIUS) return Control.BUTTON_B
-        if (x in START_LEFT..START_RIGHT && y in START_TOP..START_BOTTOM) return Control.START
+        if (startRect.contains(x, y)) return Control.START
+        if (selectRect.contains(x, y)) return Control.SELECT
 
         // D-pad: inside the cross's bounding box, pick the dominant axis
         dx = x - DPAD_CX
@@ -79,36 +78,39 @@ object TouchGamepadLayout {
     }
 }
 
-/** Draws the touch gamepad. Only invoked when touch mode is active. */
+/** Draws the touch controls on the shell body. */
 class TouchGamepadRenderer {
 
-    private val padPaint = Paint().apply {
-        color = Color.argb(150, 35, 35, 40)
-        style = Paint.Style.FILL
-    }
+    private val padPaint = Paint().apply { color = Color.rgb(35, 35, 45); style = Paint.Style.FILL }
     private val padEdgePaint = Paint().apply {
-        color = Color.argb(180, 210, 210, 215)
+        color = Color.rgb(90, 75, 15)
         strokeWidth = 4f
         style = Paint.Style.STROKE
     }
     private val buttonPaint = Paint().apply {
-        color = Color.argb(170, 150, 30, 70) // classic burgundy
+        color = Color.rgb(150, 30, 70) // classic burgundy
         style = Paint.Style.FILL
     }
     private val buttonTextPaint = Paint().apply {
-        color = Color.argb(230, 255, 255, 255)
-        textSize = 56f
+        color = Color.argb(235, 255, 255, 255)
+        textSize = 54f
+        textAlign = Paint.Align.CENTER
+        typeface = Typeface.DEFAULT_BOLD
+    }
+    private val pillTextPaint = Paint().apply {
+        color = Color.rgb(80, 62, 10)
+        textSize = 27f
         textAlign = Paint.Align.CENTER
         typeface = Typeface.DEFAULT_BOLD
     }
     private val captionPaint = Paint().apply {
-        color = Color.argb(200, 60, 60, 65)
+        color = Color.rgb(110, 85, 12)
         textSize = 26f
         textAlign = Paint.Align.CENTER
         typeface = Typeface.DEFAULT_BOLD
     }
     private val arrowPaint = Paint().apply {
-        color = Color.argb(180, 220, 220, 225)
+        color = Color.rgb(190, 190, 200)
         style = Paint.Style.FILL
     }
     private val horizontalRect = RectF(
@@ -123,12 +125,6 @@ class TouchGamepadRenderer {
         TouchGamepadLayout.DPAD_CX + TouchGamepadLayout.DPAD_THICK / 2,
         TouchGamepadLayout.DPAD_CY + TouchGamepadLayout.DPAD_ARM
     )
-    private val startRect = RectF(
-        TouchGamepadLayout.START_LEFT,
-        TouchGamepadLayout.START_TOP,
-        TouchGamepadLayout.START_RIGHT,
-        TouchGamepadLayout.START_BOTTOM
-    )
     private val arrowPath = Path()
 
     fun draw(canvas: Canvas) {
@@ -137,44 +133,54 @@ class TouchGamepadRenderer {
         val arm = TouchGamepadLayout.DPAD_ARM
 
         // D-pad cross
-        canvas.drawRoundRect(horizontalRect, 18f, 18f, padPaint)
-        canvas.drawRoundRect(verticalRect, 18f, 18f, padPaint)
-        canvas.drawRoundRect(horizontalRect, 18f, 18f, padEdgePaint)
-        canvas.drawRoundRect(verticalRect, 18f, 18f, padEdgePaint)
-        drawArrow(canvas, cx - arm + 34f, cy, -1f, 0f)
-        drawArrow(canvas, cx + arm - 34f, cy, 1f, 0f)
-        drawArrow(canvas, cx, cy - arm + 34f, 0f, -1f)
+        canvas.drawRoundRect(horizontalRect, 16f, 16f, padPaint)
+        canvas.drawRoundRect(verticalRect, 16f, 16f, padPaint)
+        drawArrow(canvas, cx - arm + 32f, cy, -1f, 0f)
+        drawArrow(canvas, cx + arm - 32f, cy, 1f, 0f)
+        drawArrow(canvas, cx, cy - arm + 32f, 0f, -1f)
 
         // B then A (A overlaps on top, like the real thing)
         canvas.drawCircle(TouchGamepadLayout.B_CX, TouchGamepadLayout.B_CY, TouchGamepadLayout.BUTTON_RADIUS, buttonPaint)
-        canvas.drawCircle(TouchGamepadLayout.B_CX, TouchGamepadLayout.B_CY, TouchGamepadLayout.BUTTON_RADIUS, padEdgePaint)
-        canvas.drawText("B", TouchGamepadLayout.B_CX, TouchGamepadLayout.B_CY + 20f, buttonTextPaint)
+        canvas.drawText("B", TouchGamepadLayout.B_CX, TouchGamepadLayout.B_CY + 19f, buttonTextPaint)
         canvas.drawCircle(TouchGamepadLayout.A_CX, TouchGamepadLayout.A_CY, TouchGamepadLayout.BUTTON_RADIUS, buttonPaint)
-        canvas.drawCircle(TouchGamepadLayout.A_CX, TouchGamepadLayout.A_CY, TouchGamepadLayout.BUTTON_RADIUS, padEdgePaint)
-        canvas.drawText("A", TouchGamepadLayout.A_CX, TouchGamepadLayout.A_CY + 20f, buttonTextPaint)
+        canvas.drawText("A", TouchGamepadLayout.A_CX, TouchGamepadLayout.A_CY + 19f, buttonTextPaint)
         canvas.drawText(
             "JUMP",
             TouchGamepadLayout.B_CX,
-            TouchGamepadLayout.B_CY + TouchGamepadLayout.BUTTON_RADIUS + 32f,
+            TouchGamepadLayout.B_CY + TouchGamepadLayout.BUTTON_RADIUS + 34f,
             captionPaint
         )
         canvas.drawText(
             "RUN + FELAFEL",
             TouchGamepadLayout.A_CX,
-            TouchGamepadLayout.A_CY - TouchGamepadLayout.BUTTON_RADIUS - 14f,
+            TouchGamepadLayout.A_CY - TouchGamepadLayout.BUTTON_RADIUS - 16f,
             captionPaint
         )
 
-        // START pill
-        canvas.drawRoundRect(startRect, 30f, 30f, padPaint)
-        canvas.drawRoundRect(startRect, 30f, 30f, padEdgePaint)
-        buttonTextPaint.textSize = 30f
-        canvas.drawText("START", startRect.centerX(), startRect.centerY() + 11f, buttonTextPaint)
-        buttonTextPaint.textSize = 56f
+        // SELECT / START pills
+        canvas.drawRoundRect(TouchGamepadLayout.selectRect, 29f, 29f, padPaint)
+        canvas.drawRoundRect(TouchGamepadLayout.startRect, 29f, 29f, padPaint)
+        canvas.drawRoundRect(TouchGamepadLayout.selectRect, 29f, 29f, padEdgePaint)
+        canvas.drawRoundRect(TouchGamepadLayout.startRect, 29f, 29f, padEdgePaint)
+        buttonTextPaint.textSize = 27f
+        canvas.drawText(
+            "SELECT",
+            TouchGamepadLayout.selectRect.centerX(),
+            TouchGamepadLayout.selectRect.centerY() + 10f,
+            buttonTextPaint
+        )
+        canvas.drawText(
+            "START",
+            TouchGamepadLayout.startRect.centerX(),
+            TouchGamepadLayout.startRect.centerY() + 10f,
+            buttonTextPaint
+        )
+        buttonTextPaint.textSize = 54f
+        canvas.drawText("MINCHA BREAK (PAUSE)", 540f, 1640f, pillTextPaint)
     }
 
     private fun drawArrow(canvas: Canvas, tipX: Float, tipY: Float, dirX: Float, dirY: Float) {
-        val size = 26f
+        val size = 25f
         arrowPath.reset()
         arrowPath.moveTo(tipX + dirX * size, tipY + dirY * size)
         // Perpendicular base corners


### PR DESCRIPTION
## What changed

### ESCAPE BOY COLOR™ (touch mode)
- Restyled after the classic yellow color handheld: minimal dark bezel, **wide 4:3 landscape LCD**, multicolor ESCAPE BOY COLOR logo, HANHALA® oval, dotted speaker grille, SELECT + START pills (both = Mincha Break)
- The game now plays in a **landscape 1440×1080 world inside the LCD** — much wider view. Levels are fraction-based, so all 12 re-flow automatically
- Keypad/d-pad phones are untouched: fullscreen portrait, zero on-screen controls

### Physics
- Jumps no longer feel slow-motion: gravity 0.9 → 1.6 with jump power rebalanced for the same reach (airtime ≈0.9s → ≈0.7s)
- Faster walk/run, snappier acceleration, faster felafel, Menahel ~20% faster at every level, Mashgiach 3 → 4

### CI
- Now builds and uploads the **release APK** (`escape-your-menahel-release`), signed with the debug key so it installs directly without keystore secrets

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_