### PR TITLE
Funky klezmer chiptune soundtrack with persistent mute

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ between you and the 4:15 bus to freedom.
 - **Rugelach collectibles**, score with time bonuses, 3 lives (displayed as
   black hats, naturally), and a persistent high score
 - **Pause = Mincha Break**
+- **Funky klezmer chiptune soundtrack** — a D-freygish loop synthesized at
+  runtime (square-wave lead, oom-pah triangle bass, offbeat stabs). Mute
+  with `#`/`0`/`M` on keypads or the ♪ button on the shell; the choice is
+  remembered
 - **ESCAPE BOY COLOR™ mode** — on touchscreen-only devices the game becomes
   a full retro handheld in classic yellow: a wide landscape LCD up top,
   d-pad + A/B + SELECT/START on the body below. The level re-flows into a
@@ -36,6 +40,7 @@ between you and the 4:15 bus to freedom.
 | `2` or UP | Jump (press twice for double jump) |
 | `5` or OK / CENTER | Start · run · shoot felafel · confirm |
 | `*`, `P`, or MENU | Mincha break (pause) |
+| `#`, `0`, or `M` | Klezmer on/off |
 | BACK | Exit the game |
 
 On touchscreens with no physical keys: d-pad moves, **B** jumps, **A** runs +
@@ -65,7 +70,8 @@ com.escapegame
 ├── entities      Talmid, Menahel, Mashgiach, FelafelBall, pickups
 ├── engine        GameEngine — state machine, rules, scoring
 ├── render        Theme backgrounds, HUD, overlay screens
-├── persistence   High-score storage
+├── audio         Runtime-synthesized klezmer chiptune
+├── persistence   High score + settings storage
 ├── GameView      Surface + render thread + key mapping
 └── MainActivity
 ```

--- a/app/src/main/java/com/escapegame/GameView.kt
+++ b/app/src/main/java/com/escapegame/GameView.kt
@@ -86,6 +86,9 @@ class GameView(context: Context, private val engine: GameEngine) :
                 KeyEvent.KEYCODE_MENU, KeyEvent.KEYCODE_P, KeyEvent.KEYCODE_STAR -> {
                     if (event.repeatCount == 0) engine.onPauseToggle(); true
                 }
+                KeyEvent.KEYCODE_POUND, KeyEvent.KEYCODE_0, KeyEvent.KEYCODE_M -> {
+                    if (event.repeatCount == 0) engine.toggleMute(); true
+                }
                 else -> false
             }
             if (handled) {
@@ -111,7 +114,8 @@ class GameView(context: Context, private val engine: GameEngine) :
                 KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_ENTER ->
                     engine.onActionUp()
                 KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_2, KeyEvent.KEYCODE_W,
-                KeyEvent.KEYCODE_MENU, KeyEvent.KEYCODE_P, KeyEvent.KEYCODE_STAR ->
+                KeyEvent.KEYCODE_MENU, KeyEvent.KEYCODE_P, KeyEvent.KEYCODE_STAR,
+                KeyEvent.KEYCODE_POUND, KeyEvent.KEYCODE_0, KeyEvent.KEYCODE_M ->
                     Unit // handled on key-down; consume the up event
                 else -> return super.onKeyUp(keyCode, event)
             }
@@ -142,12 +146,17 @@ class GameView(context: Context, private val engine: GameEngine) :
 
     /** Edge-triggered actions for a newly placed finger. */
     private fun handleTouchDown(event: MotionEvent, pointerIndex: Int) {
+        val control = TouchGamepadLayout.hit(worldX(event, pointerIndex), worldY(event, pointerIndex))
+        if (control == TouchGamepadLayout.Control.MUTE) {
+            engine.toggleMute()
+            return
+        }
         if (engine.phase != GamePhase.PLAYING) {
-            // Overlay screens: any tap is the confirm button
+            // Overlay screens: any other tap is the confirm button
             engine.onActionDown()
             return
         }
-        when (TouchGamepadLayout.hit(worldX(event, pointerIndex), worldY(event, pointerIndex))) {
+        when (control) {
             TouchGamepadLayout.Control.DPAD_UP,
             TouchGamepadLayout.Control.BUTTON_B -> engine.onJump()
             TouchGamepadLayout.Control.BUTTON_A -> engine.onActionDown()

--- a/app/src/main/java/com/escapegame/MainActivity.kt
+++ b/app/src/main/java/com/escapegame/MainActivity.kt
@@ -4,11 +4,13 @@ import android.app.Activity
 import android.os.Bundle
 import android.view.Window
 import android.view.WindowManager
+import com.escapegame.audio.MusicEngine
 import com.escapegame.engine.GameEngine
-import com.escapegame.persistence.HighScoreStore
+import com.escapegame.persistence.GamePrefs
 
 class MainActivity : Activity() {
     private lateinit var gameView: GameView
+    private lateinit var music: MusicEngine
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,7 +21,8 @@ class MainActivity : Activity() {
             WindowManager.LayoutParams.FLAG_FULLSCREEN
         )
 
-        val engine = GameEngine(HighScoreStore(this))
+        music = MusicEngine()
+        val engine = GameEngine(GamePrefs(this), music)
         gameView = GameView(this, engine)
         setContentView(gameView)
     }
@@ -27,10 +30,12 @@ class MainActivity : Activity() {
     override fun onResume() {
         super.onResume()
         gameView.resume()
+        music.start()
     }
 
     override fun onPause() {
         super.onPause()
         gameView.pause()
+        music.stop()
     }
 }

--- a/app/src/main/java/com/escapegame/audio/MusicEngine.kt
+++ b/app/src/main/java/com/escapegame/audio/MusicEngine.kt
@@ -1,0 +1,174 @@
+package com.escapegame.audio
+
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import kotlin.math.sin
+
+/**
+ * Funky klezmer chiptune, synthesized at runtime — no audio assets, no
+ * downloads, fully kosher for the tiniest APK.
+ *
+ * A four-bar loop in D freygish (Ahava Raba mode): square-wave lead with a
+ * little vibrato, triangle oom-pah bass, and offbeat chord stabs for the
+ * funk. Streams to an [AudioTrack] from its own low-priority thread; mute
+ * simply zeroes the output so the loop position is preserved.
+ */
+class MusicEngine {
+
+    @Volatile
+    private var muted = false
+
+    @Volatile
+    private var running = false
+    private var thread: Thread? = null
+
+    fun isMuted(): Boolean = muted
+
+    fun setMuted(value: Boolean) {
+        muted = value
+    }
+
+    fun start() {
+        if (thread?.isAlive == true) return
+        running = true
+        thread = Thread(this::runLoop, "MusicEngine").also {
+            it.isDaemon = true
+            it.priority = Thread.MIN_PRIORITY + 1
+            it.start()
+        }
+    }
+
+    fun stop() {
+        running = false
+        try {
+            thread?.join(500)
+        } catch (e: InterruptedException) {
+            // Shutting down anyway
+        }
+        thread = null
+    }
+
+    private fun runLoop() {
+        val minBuffer = AudioTrack.getMinBufferSize(
+            SAMPLE_RATE, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT
+        )
+        if (minBuffer <= 0) return
+        @Suppress("DEPRECATION")
+        val track = AudioTrack(
+            AudioManager.STREAM_MUSIC,
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_OUT_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+            maxOf(minBuffer, 8192),
+            AudioTrack.MODE_STREAM
+        )
+        if (track.state != AudioTrack.STATE_INITIALIZED) {
+            track.release()
+            return
+        }
+        track.play()
+
+        val buffer = ShortArray(2048)
+        var sample = 0L
+        while (running) {
+            for (i in buffer.indices) {
+                buffer[i] = synthesize(sample + i)
+            }
+            sample += buffer.size
+            // Blocking write paces the loop at real time
+            track.write(buffer, 0, buffer.size)
+        }
+        track.stop()
+        track.release()
+    }
+
+    // Oscillator phase accumulators (avoid float-precision drift over time)
+    private var leadPhase = 0f
+    private var bassPhase = 0f
+    private var stabPhase = 0f
+    private var vibratoPhase = 0f
+
+    private fun synthesize(sample: Long): Short {
+        val slot = ((sample / SAMPLES_PER_EIGHTH) % SLOTS).toInt()
+        val posInSlot = (sample % SAMPLES_PER_EIGHTH).toFloat() / SAMPLES_PER_EIGHTH
+
+        var mix = 0f
+
+        // Lead: square wave with vibrato and a per-note decay envelope
+        val leadFreq = LEAD[slot]
+        vibratoPhase = wrap(vibratoPhase + 5.5f / SAMPLE_RATE)
+        if (leadFreq > 0f) {
+            val vibrato = 1f + 0.006f * sin(TWO_PI * vibratoPhase)
+            leadPhase = wrap(leadPhase + leadFreq * vibrato / SAMPLE_RATE)
+            val square = if (leadPhase < 0.5f) 1f else -1f
+            mix += square * 0.16f * (1f - 0.65f * posInSlot)
+        }
+
+        // Bass: triangle "oom" on the beat, sustained across two slots
+        val bassFreq = BASS[slot and 0x1E]
+        if (bassFreq > 0f) {
+            bassPhase = wrap(bassPhase + bassFreq / SAMPLE_RATE)
+            val triangle = 4f * kotlin.math.abs(bassPhase - 0.5f) - 1f
+            val bassPos = ((slot and 1) + posInSlot) / 2f
+            mix += triangle * 0.24f * (1f - 0.45f * bassPos)
+        }
+
+        // Offbeat "pah": a short chord stab for the funk
+        if (slot and 1 == 1 && posInSlot < 0.5f) {
+            val stabFreq = STAB_TONES[slot / 8]
+            stabPhase = wrap(stabPhase + stabFreq / SAMPLE_RATE)
+            val square = if (stabPhase < 0.5f) 1f else -1f
+            mix += square * 0.07f * (1f - 2f * posInSlot)
+        }
+
+        if (muted) return 0
+        val clamped = mix.coerceIn(-1f, 1f)
+        return (clamped * 30000f).toInt().toShort()
+    }
+
+    private fun wrap(phase: Float): Float = if (phase >= 1f) phase - 1f else phase
+
+    private companion object {
+        const val SAMPLE_RATE = 22050
+        const val TWO_PI = (2.0 * Math.PI).toFloat()
+
+        // ~140 BPM: one eighth note per slot
+        const val SAMPLES_PER_EIGHTH = 4725L
+        const val SLOTS = 32
+
+        // D freygish (Ahava Raba): D Eb F# G A Bb C
+        const val D3 = 146.83f
+        const val G2 = 98.00f
+        const val A2 = 110.00f
+        const val BB2 = 116.54f
+        const val C3 = 130.81f
+        const val D4 = 293.66f
+        const val EB4 = 311.13f
+        const val FS4 = 369.99f
+        const val G4 = 392.00f
+        const val A4 = 440.00f
+        const val BB4 = 466.16f
+        const val C5 = 523.25f
+        const val D5 = 587.33f
+
+        /** Four bars of melody, one note per eighth (0 = rest). */
+        val LEAD = floatArrayOf(
+            D4, FS4, A4, D5, C5, BB4, A4, G4,
+            FS4, G4, A4, BB4, A4, G4, FS4, EB4,
+            D4, D4, FS4, FS4, A4, A4, D5, D5,
+            C5, BB4, A4, G4, FS4, EB4, D4, 0f
+        )
+
+        /** Oom-pah bass: notes land on even slots, sustained through the odd. */
+        val BASS = floatArrayOf(
+            D3, 0f, A2, 0f, D3, 0f, A2, 0f,
+            C3, 0f, G2, 0f, C3, 0f, G2, 0f,
+            D3, 0f, A2, 0f, D3, 0f, A2, 0f,
+            BB2, 0f, G2, 0f, A2, 0f, A2, 0f
+        )
+
+        /** One stab chord tone per bar. */
+        val STAB_TONES = floatArrayOf(220f, 196f, 220f, 220f)
+    }
+}

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -16,7 +16,8 @@ import com.escapegame.model.GamePhase
 import com.escapegame.model.LevelDefinition
 import com.escapegame.model.Platform
 import com.escapegame.model.PowerUpType
-import com.escapegame.persistence.HighScoreStore
+import com.escapegame.audio.MusicEngine
+import com.escapegame.persistence.GamePrefs
 import com.escapegame.render.BackgroundRenderer
 import com.escapegame.render.HudRenderer
 import com.escapegame.render.GameBoyShellRenderer
@@ -34,7 +35,10 @@ import kotlin.random.Random
  * Not internally synchronized: the hosting view calls every public method
  * under a single lock.
  */
-class GameEngine(private val highScores: HighScoreStore) {
+class GameEngine(
+    private val prefs: GamePrefs,
+    private val music: MusicEngine
+) {
 
     private var worldWidth = GameConfig.WORLD_WIDTH
     private var worldHeight = GameConfig.WORLD_HEIGHT
@@ -60,7 +64,7 @@ class GameEngine(private val highScores: HighScoreStore) {
     private var lives = GameConfig.STARTING_LIVES
     private var levelFrames = 0
     private var phaseFrames = 0
-    private var highScore = highScores.getHighScore()
+    private var highScore = prefs.getHighScore()
     private var newBest = false
     private var gameOverLine = Levels.gameOverLines.first()
 
@@ -71,7 +75,17 @@ class GameEngine(private val highScores: HighScoreStore) {
     init {
         // Populate level 1 so the intro screen has a real backdrop
         buildLevel(0)
+        music.setMuted(prefs.isMusicMuted())
     }
+
+    /** Flips the funky-klezmer soundtrack on/off and persists the choice. */
+    fun toggleMute() {
+        val newMuted = !music.isMuted()
+        music.setMuted(newMuted)
+        prefs.setMusicMuted(newMuted)
+    }
+
+    fun isMusicMuted(): Boolean = music.isMuted()
 
     /**
      * True when the handheld-shell presentation should be used: set by the
@@ -377,7 +391,7 @@ class GameEngine(private val highScores: HighScoreStore) {
         lives--
         if (lives <= 0) {
             gameOverLine = Levels.gameOverLines[Random.nextInt(Levels.gameOverLines.size)]
-            newBest = highScores.submitScore(score)
+            newBest = prefs.submitScore(score)
             if (newBest) highScore = score
             phase = GamePhase.GAME_OVER
             phaseFrames = 0
@@ -403,7 +417,7 @@ class GameEngine(private val highScores: HighScoreStore) {
         score += GameConfig.SCORE_LEVEL_CLEAR + timeBonus
 
         if (levelIndex + 1 >= Levels.all.size) {
-            newBest = highScores.submitScore(score)
+            newBest = prefs.submitScore(score)
             if (newBest) highScore = score
             phase = GamePhase.VICTORY
             phaseFrames = 0
@@ -451,7 +465,7 @@ class GameEngine(private val highScores: HighScoreStore) {
             canvas.clipRect(0f, 0f, worldWidth, worldHeight)
             drawWorldAndUi(canvas)
             canvas.restore()
-            gamepad.draw(canvas)
+            gamepad.draw(canvas, music.isMuted())
         } else {
             drawWorldAndUi(canvas)
         }

--- a/app/src/main/java/com/escapegame/persistence/GamePrefs.kt
+++ b/app/src/main/java/com/escapegame/persistence/GamePrefs.kt
@@ -2,8 +2,8 @@ package com.escapegame.persistence
 
 import android.content.Context
 
-/** Persists the best escape (high score) across app launches. */
-class HighScoreStore(context: Context) {
+/** Persists the best escape (high score) and settings across app launches. */
+class GamePrefs(context: Context) {
 
     private val prefs =
         context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -19,8 +19,15 @@ class HighScoreStore(context: Context) {
         return false
     }
 
+    fun isMusicMuted(): Boolean = prefs.getBoolean(KEY_MUTED, false)
+
+    fun setMusicMuted(muted: Boolean) {
+        prefs.edit().putBoolean(KEY_MUTED, muted).apply()
+    }
+
     private companion object {
         const val PREFS_NAME = "escape_menahel"
         const val KEY_HIGH_SCORE = "high_score"
+        const val KEY_MUTED = "music_muted"
     }
 }

--- a/app/src/main/java/com/escapegame/render/HudRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/HudRenderer.kt
@@ -76,7 +76,7 @@ class HudRenderer(private val w: Float) {
     fun drawControlsHint(canvas: Canvas, worldHeight: Float) {
         smallTextPaint.color = Color.BLACK
         canvas.drawText(
-            "4/6 or ◀▶ move · 2/▲ jump · 5/OK run+felafel",
+            "4/6 move · 2 jump · 5 run+felafel · #/0 ♪",
             20f,
             worldHeight - 24f,
             smallTextPaint

--- a/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
@@ -99,7 +99,8 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
         canvas.drawText("4 / 6  or  LEFT / RIGHT — move", w / 2, y, bodyPaint); y += lh
         canvas.drawText("2  or  UP — jump (twice = double jump)", w / 2, y, bodyPaint); y += lh
         canvas.drawText("5  or  OK — run + shoot felafel", w / 2, y, bodyPaint); y += lh
-        canvas.drawText("P / MENU — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.8f
+        canvas.drawText("P / MENU — mincha break (pause)", w / 2, y, bodyPaint); y += lh
+        canvas.drawText("0 / # — klezmer on/off", w / 2, y, bodyPaint); y += lh * 1.8f
 
         canvas.drawText("Grab rugelach. Chap the power-ups.", w / 2, y, bodyPaint); y += lh
         canvas.drawText("12 levels between you and the 4:15 bus.", w / 2, y, bodyPaint); y += lh * 1.6f

--- a/app/src/main/java/com/escapegame/render/TouchGamepad.kt
+++ b/app/src/main/java/com/escapegame/render/TouchGamepad.kt
@@ -18,7 +18,7 @@ import com.escapegame.core.GameConfig
  */
 object TouchGamepadLayout {
 
-    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, BUTTON_A, BUTTON_B, START, SELECT, NONE }
+    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, BUTTON_A, BUTTON_B, START, SELECT, MUTE, NONE }
 
     // Shell geometry: a wide, minimal bezel around a 4:3 landscape LCD;
     // the game world (1440x1080) fits it exactly.
@@ -52,6 +52,9 @@ object TouchGamepadLayout {
     val selectRect = RectF(350f, 1520f, 520f, 1578f)
     val startRect = RectF(560f, 1520f, 730f, 1578f)
 
+    // Music mute button in the bezel's top strip
+    val muteRect = RectF(905f, 76f, 1028f, 114f)
+
     fun hit(x: Float, y: Float): Control {
         var dx = x - A_CX
         var dy = y - A_CY
@@ -61,6 +64,7 @@ object TouchGamepadLayout {
         if (dx * dx + dy * dy <= BUTTON_RADIUS * BUTTON_RADIUS) return Control.BUTTON_B
         if (startRect.contains(x, y)) return Control.START
         if (selectRect.contains(x, y)) return Control.SELECT
+        if (muteRect.contains(x, y)) return Control.MUTE
 
         // D-pad: inside the cross's bounding box, pick the dominant axis
         dx = x - DPAD_CX
@@ -127,7 +131,18 @@ class TouchGamepadRenderer {
     )
     private val arrowPath = Path()
 
-    fun draw(canvas: Canvas) {
+    fun draw(canvas: Canvas, musicMuted: Boolean) {
+        // Mute toggle up in the bezel strip, by the LED
+        canvas.drawRoundRect(TouchGamepadLayout.muteRect, 19f, 19f, padPaint)
+        buttonTextPaint.textSize = 24f
+        canvas.drawText(
+            if (musicMuted) "\u266a OFF" else "\u266a ON",
+            TouchGamepadLayout.muteRect.centerX(),
+            TouchGamepadLayout.muteRect.centerY() + 9f,
+            buttonTextPaint
+        )
+        buttonTextPaint.textSize = 54f
+
         val cx = TouchGamepadLayout.DPAD_CX
         val cy = TouchGamepadLayout.DPAD_CY
         val arm = TouchGamepadLayout.DPAD_ARM


### PR DESCRIPTION
## What changed

- **`audio/MusicEngine`** — a four-bar D-freygish (Ahava Raba) klezmer chiptune loop, synthesized at runtime straight to `AudioTrack`: square-wave lead with vibrato, triangle oom-pah bass, and offbeat chord stabs for the funk. Zero audio assets; phase-accumulator oscillators avoid drift; the blocking write paces the loop; mute zeroes the output so the loop position is preserved.
- **Mute button**: `#` / `0` / `M` on keypad phones, a ♪ ON/OFF button in the shell bezel in touch mode. Choice persists across launches.
- `HighScoreStore` generalized to `GamePrefs` (high score + settings).
- Music follows the activity lifecycle (starts on resume, stops on pause).
- Intro screen and HUD hint document the mute key.

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_