### PR TITLE
Levels 13–18, level modifiers, and synthesized sound effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ between you and the 4:15 bus to freedom.
 
 ## Features
 
-- **12 handcrafted levels** — from the lunchroom, through the beis medrash and
-  Detention Row, to the roof (assur!), the parking lot, and the 4:15 bus stop
+- **18 handcrafted levels** — from the lunchroom, through the beis medrash,
+  Detention Row, the roof (assur!), the coat room, the mikveh, the
+  fire-escape sukkah, the shul kiddush, and the simcha hall, all the way to
+  the Mesivta Van
+- **Level modifiers** — wet floors (no traction), lights-out levels (follow
+  your little circle of ner), rooftop wind, the Assistant Menahel (two
+  menahelim?!), and a final level where the van leaves in 75 seconds
 - **The Menahel** — chases you relentlessly, gets faster every level, and
   yells authentic mussar in speech bubbles ("Where's your HAT?!", "I ran track
   in '87!")
@@ -22,8 +27,9 @@ between you and the 4:15 bus to freedom.
 - **Rugelach collectibles**, score with time bonuses, 3 lives (displayed as
   black hats, naturally), and a persistent high score
 - **Pause = Mincha Break**
-- **Funky klezmer chiptune soundtrack** — a D-freygish loop synthesized at
-  runtime (square-wave lead, oom-pah triangle bass, offbeat stabs). Mute
+- **Funky klezmer chiptune soundtrack + sound effects** — a D-freygish loop
+  and all SFX (jump blips, felafel pfft, pickup dings, stun warbles, caught
+  womps, level fanfares) synthesized at runtime, zero audio assets. Mute
   with `#`/`0`/`M` on keypads or the ♪ button on the shell; the choice is
   remembered
 - **ESCAPE BOY COLOR™ mode** — on touchscreen-only devices the game becomes

--- a/app/src/main/java/com/escapegame/audio/MusicEngine.kt
+++ b/app/src/main/java/com/escapegame/audio/MusicEngine.kt
@@ -3,16 +3,29 @@ package com.escapegame.audio
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
+import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.math.sin
 
+/** One-shot sound effects, synthesized like everything else. */
+enum class Sfx {
+    JUMP,
+    THROW,
+    PICKUP,
+    POWERUP,
+    STUN,
+    CAUGHT,
+    LEVEL_CLEAR
+}
+
 /**
- * Funky klezmer chiptune, synthesized at runtime — no audio assets, no
- * downloads, fully kosher for the tiniest APK.
+ * Funky klezmer chiptune plus sound effects, synthesized at runtime — no
+ * audio assets, no downloads, fully kosher for the tiniest APK.
  *
- * A four-bar loop in D freygish (Ahava Raba mode): square-wave lead with a
- * little vibrato, triangle oom-pah bass, and offbeat chord stabs for the
- * funk. Streams to an [AudioTrack] from its own low-priority thread; mute
- * simply zeroes the output so the loop position is preserved.
+ * Music: a four-bar loop in D freygish (Ahava Raba mode): square-wave lead
+ * with a little vibrato, triangle oom-pah bass, and offbeat chord stabs for
+ * the funk. SFX are short synthesized voices mixed into the same stream.
+ * Streams to an [AudioTrack] from its own low-priority thread; mute simply
+ * zeroes the output so the loop position is preserved.
  */
 class MusicEngine {
 
@@ -23,10 +36,17 @@ class MusicEngine {
     private var running = false
     private var thread: Thread? = null
 
+    private val voices = ConcurrentLinkedQueue<Voice>()
+
     fun isMuted(): Boolean = muted
 
     fun setMuted(value: Boolean) {
         muted = value
+    }
+
+    /** Queues a sound effect; cheap and thread-safe. */
+    fun playSfx(type: Sfx) {
+        if (voices.size < MAX_VOICES) voices.add(Voice(type))
     }
 
     fun start() {
@@ -69,19 +89,27 @@ class MusicEngine {
         }
         track.play()
 
-        val buffer = ShortArray(2048)
+        val mix = FloatArray(2048)
+        val out = ShortArray(mix.size)
         var sample = 0L
         while (running) {
-            for (i in buffer.indices) {
-                buffer[i] = synthesize(sample + i)
+            for (i in mix.indices) {
+                mix[i] = musicSample(sample + i)
             }
-            sample += buffer.size
+            sample += mix.size
+            mixVoices(mix)
+            for (i in mix.indices) {
+                val value = if (muted) 0f else mix[i].coerceIn(-1f, 1f)
+                out[i] = (value * 30000f).toInt().toShort()
+            }
             // Blocking write paces the loop at real time
-            track.write(buffer, 0, buffer.size)
+            track.write(out, 0, out.size)
         }
         track.stop()
         track.release()
     }
+
+    // ------------------------------------------------------------- the tune
 
     // Oscillator phase accumulators (avoid float-precision drift over time)
     private var leadPhase = 0f
@@ -89,7 +117,7 @@ class MusicEngine {
     private var stabPhase = 0f
     private var vibratoPhase = 0f
 
-    private fun synthesize(sample: Long): Short {
+    private fun musicSample(sample: Long): Float {
         val slot = ((sample / SAMPLES_PER_EIGHTH) % SLOTS).toInt()
         val posInSlot = (sample % SAMPLES_PER_EIGHTH).toFloat() / SAMPLES_PER_EIGHTH
 
@@ -122,16 +150,105 @@ class MusicEngine {
             mix += square * 0.07f * (1f - 2f * posInSlot)
         }
 
-        if (muted) return 0
-        val clamped = mix.coerceIn(-1f, 1f)
-        return (clamped * 30000f).toInt().toShort()
+        return mix
     }
 
     private fun wrap(phase: Float): Float = if (phase >= 1f) phase - 1f else phase
 
+    // ------------------------------------------------------------------ sfx
+
+    private class Voice(val type: Sfx) {
+        var pos = 0
+    }
+
+    private fun mixVoices(out: FloatArray) {
+        val iterator = voices.iterator()
+        while (iterator.hasNext()) {
+            val voice = iterator.next()
+            val duration = voiceDuration(voice.type)
+            var i = 0
+            while (i < out.size && voice.pos < duration) {
+                out[i] += voiceSample(voice.type, voice.pos)
+                voice.pos++
+                i++
+            }
+            if (voice.pos >= duration) iterator.remove()
+        }
+    }
+
+    private fun voiceDuration(type: Sfx): Int = when (type) {
+        Sfx.JUMP -> (0.10f * SAMPLE_RATE).toInt()
+        Sfx.THROW -> (0.08f * SAMPLE_RATE).toInt()
+        Sfx.PICKUP -> (0.12f * SAMPLE_RATE).toInt()
+        Sfx.POWERUP -> (0.24f * SAMPLE_RATE).toInt()
+        Sfx.STUN -> (0.25f * SAMPLE_RATE).toInt()
+        Sfx.CAUGHT -> (0.40f * SAMPLE_RATE).toInt()
+        Sfx.LEVEL_CLEAR -> (0.48f * SAMPLE_RATE).toInt()
+    }
+
+    private fun voiceSample(type: Sfx, pos: Int): Float {
+        val t = pos.toFloat() / SAMPLE_RATE
+        return when (type) {
+            Sfx.JUMP -> {
+                // Rising square blip, 180 -> 520 Hz
+                val phase = 180.0 * t + 1700.0 * t * t
+                square(phase) * 0.20f * envelope(t, 0.10f)
+            }
+            Sfx.THROW -> {
+                // A short "pfft" of noise
+                noise(pos) * 0.16f * envelope(t, 0.08f)
+            }
+            Sfx.PICKUP -> {
+                // Two-note ding: E5-ish then B5-ish
+                val freq = if (t < 0.05f) 660.0 else 990.0
+                sin(TWO_PI_D * freq * t).toFloat() * 0.22f * envelope(t, 0.12f)
+            }
+            Sfx.POWERUP -> {
+                // Freygish arpeggio, one note per 60ms
+                val notes = ARPEGGIO
+                val idx = (t / 0.06f).toInt().coerceAtMost(notes.size - 1)
+                val noteT = t - idx * 0.06f
+                square(notes[idx] * t.toDouble()) * 0.17f * envelope(noteT, 0.06f)
+            }
+            Sfx.STUN -> {
+                // Dizzy wobble: FM warble
+                val arg = TWO_PI_D * 300.0 * t + 4.0 * sin(TWO_PI_D * 9.0 * t)
+                sin(arg).toFloat() * 0.20f * envelope(t, 0.25f)
+            }
+            Sfx.CAUGHT -> {
+                // Descending womp, 220 -> 70 Hz
+                val phase = 220.0 * t - 187.5 * t * t
+                square(phase) * 0.26f * envelope(t, 0.40f)
+            }
+            Sfx.LEVEL_CLEAR -> {
+                // Little fanfare up the scale
+                val notes = FANFARE
+                val idx = (t / 0.12f).toInt().coerceAtMost(notes.size - 1)
+                val noteT = t - idx * 0.12f
+                square(notes[idx] * t.toDouble()) * 0.20f * envelope(noteT, 0.12f)
+            }
+        }
+    }
+
+    /** Square wave from a phase given in cycles. */
+    private fun square(phaseCycles: Double): Float =
+        if (sin(TWO_PI_D * phaseCycles) >= 0.0) 1f else -1f
+
+    /** Linear decay envelope over [duration] seconds. */
+    private fun envelope(t: Float, duration: Float): Float =
+        (1f - t / duration).coerceIn(0f, 1f)
+
+    /** Deterministic cheap noise from the sample index. */
+    private fun noise(pos: Int): Float {
+        val hashed = pos * 1103515245 + 12345
+        return ((hashed ushr 16) and 0x7fff) / 16384f - 1f
+    }
+
     private companion object {
         const val SAMPLE_RATE = 22050
         const val TWO_PI = (2.0 * Math.PI).toFloat()
+        const val TWO_PI_D = 2.0 * Math.PI
+        const val MAX_VOICES = 8
 
         // ~140 BPM: one eighth note per slot
         const val SAMPLES_PER_EIGHTH = 4725L
@@ -170,5 +287,8 @@ class MusicEngine {
 
         /** One stab chord tone per bar. */
         val STAB_TONES = floatArrayOf(220f, 196f, 220f, 220f)
+
+        val ARPEGGIO = doubleArrayOf(293.66, 369.99, 440.0, 587.33)
+        val FANFARE = doubleArrayOf(293.66, 440.0, 587.33, 739.99)
     }
 }

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -13,10 +13,12 @@ import com.escapegame.entities.Rugelach
 import com.escapegame.entities.Talmid
 import com.escapegame.levels.Levels
 import com.escapegame.model.GamePhase
+import com.escapegame.model.Modifier
 import com.escapegame.model.LevelDefinition
 import com.escapegame.model.Platform
 import com.escapegame.model.PowerUpType
 import com.escapegame.audio.MusicEngine
+import com.escapegame.audio.Sfx
 import com.escapegame.persistence.GamePrefs
 import com.escapegame.render.BackgroundRenderer
 import com.escapegame.render.HudRenderer
@@ -51,6 +53,7 @@ class GameEngine(
 
     private val talmid = Talmid()
     private val menahel = Menahel()
+    private val assistants = mutableListOf<Menahel>()
     private val mashgichim = mutableListOf<Mashgiach>()
     private val platforms = mutableListOf<Platform>()
     private val felafelBalls = mutableListOf<FelafelBall>()
@@ -64,6 +67,8 @@ class GameEngine(
     private var lives = GameConfig.STARTING_LIVES
     private var levelFrames = 0
     private var phaseFrames = 0
+    /** Frames until the van leaves without you; -1 when the level has no timer. */
+    private var vanFrames = -1
     private var highScore = prefs.getHighScore()
     private var newBest = false
     private var gameOverLine = Levels.gameOverLines.first()
@@ -112,6 +117,12 @@ class GameEngine(
         typeface = Typeface.DEFAULT_BOLD
         style = Paint.Style.FILL
     }
+    // DARK modifier: a huge stroked ring leaves a lit circle around the talmid
+    private val darknessPaint = Paint().apply {
+        color = Color.argb(233, 5, 5, 14)
+        style = Paint.Style.STROKE
+        strokeWidth = 4200f
+    }
 
     // ---------------------------------------------------------------- input
 
@@ -124,7 +135,9 @@ class GameEngine(
     }
 
     fun onJump() {
-        if (phase == GamePhase.PLAYING) talmid.jump()
+        if (phase == GamePhase.PLAYING && talmid.jump()) {
+            music.playSfx(Sfx.JUMP)
+        }
     }
 
     /** CENTER / 5 / OK pressed: the universal confirm-and-action button. */
@@ -134,7 +147,10 @@ class GameEngine(
             GamePhase.LEVEL_INTRO -> beginPlay()
             GamePhase.PLAYING -> {
                 runPressed = true
-                talmid.shootFelafel()?.let { felafelBalls.add(it) }
+                talmid.shootFelafel()?.let {
+                    felafelBalls.add(it)
+                    music.playSfx(Sfx.THROW)
+                }
             }
             GamePhase.PAUSED -> resumePlay()
             GamePhase.GAME_OVER -> startNewGame()
@@ -252,6 +268,19 @@ class GameEngine(
         talmid.resetForLevel(playerStartX, floorTop)
         menahel.resetForLevel(worldWidth * 0.72f, floorTop, level.menahelSpeed)
 
+        assistants.clear()
+        if (Modifier.ASSISTANT_MENAHEL in level.modifiers) {
+            val assistant = Menahel("ASST. MENAHEL")
+            // Slightly slower than the boss, but he starts closer
+            assistant.resetForLevel(worldWidth * 0.45f, floorTop, level.menahelSpeed * 0.8f)
+            assistants.add(assistant)
+        }
+
+        talmid.frictionFactor =
+            if (Modifier.SLIPPERY in level.modifiers) 0.975f else GameConfig.PLAYER_FRICTION
+        talmid.windEnabled = Modifier.WIND in level.modifiers
+        vanFrames = level.timeLimitSeconds?.times(60) ?: -1
+
         levelFrames = 0
         phaseFrames = 0
     }
@@ -289,7 +318,15 @@ class GameEngine(
 
         talmid.update(worldWidth, floorTop, platforms)
         menahel.update(talmid.centerX, worldWidth, floorTop, platforms)
+        for (a in assistants) a.update(talmid.centerX, worldWidth, floorTop, platforms)
         for (m in mashgichim) m.update()
+
+        if (vanFrames > 0) {
+            vanFrames--
+            if (vanFrames == 0) {
+                onVanLeft()
+            }
+        }
 
         updateFelafel()
         updatePickups()
@@ -309,7 +346,24 @@ class GameEngine(
             }
             if (ball.hits(menahel.centerX, menahel.centerY, GameConfig.MENAHEL_CATCH_DISTANCE)) {
                 menahel.stun()
+                music.playSfx(Sfx.STUN)
                 addFloatingText("BULLSEYE!", menahel.centerX, menahel.y - 40f, Color.rgb(255, 160, 40))
+                iterator.remove()
+                continue
+            }
+            var hitAssistant = false
+            for (a in assistants) {
+                if (!a.isStunned &&
+                    ball.hits(a.centerX, a.centerY, GameConfig.MENAHEL_CATCH_DISTANCE)
+                ) {
+                    a.stun()
+                    music.playSfx(Sfx.STUN)
+                    addFloatingText("Also him!", a.centerX, a.y - 40f, Color.rgb(255, 160, 40))
+                    hitAssistant = true
+                    break
+                }
+            }
+            if (hitAssistant) {
                 iterator.remove()
                 continue
             }
@@ -319,6 +373,7 @@ class GameEngine(
                     ball.hits(m.centerX, m.centerY, GameConfig.MASHGIACH_CATCH_DISTANCE)
                 ) {
                     m.stun()
+                    music.playSfx(Sfx.STUN)
                     addFloatingText("Lost his place!", m.centerX, m.y - 40f, Color.rgb(255, 160, 40))
                     hitPatroller = true
                     break
@@ -332,6 +387,7 @@ class GameEngine(
         for (r in rugelach) {
             r.update()
             if (r.tryCollect(talmid.centerX, talmid.centerY, 60f)) {
+                music.playSfx(Sfx.PICKUP)
                 score += GameConfig.SCORE_RUGELACH
                 addFloatingText(
                     "+${GameConfig.SCORE_RUGELACH}",
@@ -342,6 +398,7 @@ class GameEngine(
         for (p in powerUps) {
             p.update()
             if (p.tryCollect(talmid.centerX, talmid.centerY, 65f)) {
+                music.playSfx(Sfx.POWERUP)
                 score += GameConfig.SCORE_POWER_UP
                 when (p.type) {
                     PowerUpType.COFFEE -> talmid.applyCoffee()
@@ -362,6 +419,14 @@ class GameEngine(
             onCaught()
             return
         }
+        for (a in assistants) {
+            if (!a.isStunned &&
+                withinDistance(a.centerX, a.centerY, GameConfig.MENAHEL_CATCH_DISTANCE)
+            ) {
+                onCaught()
+                return
+            }
+        }
         for (m in mashgichim) {
             if (!m.isStunned &&
                 withinDistance(m.centerX, m.centerY, GameConfig.MASHGIACH_CATCH_DISTANCE)
@@ -381,13 +446,23 @@ class GameEngine(
     private fun onCaught() {
         if (talmid.consumeShield()) {
             menahel.stun()
+            music.playSfx(Sfx.STUN)
             addFloatingText(
                 "The kugel took the hit!",
                 talmid.centerX, talmid.y - 70f, Color.rgb(200, 150, 0)
             )
             return
         }
+        loseLife("CAUGHT! Minus one hat.")
+    }
 
+    private fun onVanLeft() {
+        loseLife("THE VAN LEFT! ...It's circling the block. GO!")
+        vanFrames = level.timeLimitSeconds?.times(60) ?: -1
+    }
+
+    private fun loseLife(message: String) {
+        music.playSfx(Sfx.CAUGHT)
         lives--
         if (lives <= 0) {
             gameOverLine = Levels.gameOverLines[Random.nextInt(Levels.gameOverLines.size)]
@@ -397,7 +472,7 @@ class GameEngine(
             phaseFrames = 0
         } else {
             addFloatingText(
-                "CAUGHT! Minus one hat.",
+                message,
                 talmid.centerX, talmid.y - 70f, Color.rgb(220, 40, 40)
             )
             talmid.respawn(playerStartX, floorTop)
@@ -415,6 +490,7 @@ class GameEngine(
         val timeBonus = (GameConfig.TIME_BONUS_MAX - seconds * GameConfig.TIME_BONUS_DECAY_PER_SECOND)
             .coerceAtLeast(0)
         score += GameConfig.SCORE_LEVEL_CLEAR + timeBonus
+        music.playSfx(Sfx.LEVEL_CLEAR)
 
         if (levelIndex + 1 >= Levels.all.size) {
             newBest = prefs.submitScore(score)
@@ -484,13 +560,22 @@ class GameEngine(
             for (p in powerUps) p.draw(canvas)
             for (m in mashgichim) m.draw(canvas)
             menahel.draw(canvas, worldWidth)
+            for (a in assistants) a.draw(canvas, worldWidth)
             talmid.draw(canvas)
             for (ball in felafelBalls) ball.draw(canvas)
             for (t in floatingTexts) {
                 floatingTextPaint.color = t.color
                 canvas.drawText(t.text, t.x, t.y, floatingTextPaint)
             }
-            hud.draw(canvas, score, highScore, lives, level, talmid)
+            if (Modifier.DARK in level.modifiers && phase == GamePhase.PLAYING) {
+                // Everything outside the talmid's little circle of light
+                canvas.drawCircle(
+                    talmid.centerX, talmid.centerY,
+                    300f + darknessPaint.strokeWidth / 2, darknessPaint
+                )
+            }
+            val vanSeconds = if (vanFrames >= 0) (vanFrames + 59) / 60 else null
+            hud.draw(canvas, score, highScore, lives, level, talmid, vanSeconds)
             if (!touchControlsEnabled) {
                 hud.drawControlsHint(canvas, worldHeight)
             }

--- a/app/src/main/java/com/escapegame/entities/Menahel.kt
+++ b/app/src/main/java/com/escapegame/entities/Menahel.kt
@@ -17,7 +17,7 @@ import kotlin.random.Random
  * stunned by a well-aimed felafel, and periodically yells mussar in a speech
  * bubble.
  */
-class Menahel {
+class Menahel(private val title: String = "MENAHEL") {
     var x = 500f
         private set
     var y = 500f
@@ -182,7 +182,7 @@ class Menahel {
         canvas.drawOval(x + 3, y + height - 11, x + 26, y + height + 4, shoePaint)
         canvas.drawOval(x + s - 26, y + height - 11, x + s - 3, y + height + 4, shoePaint)
 
-        canvas.drawText("MENAHEL", x + s / 2, y + height + 26, labelPaint)
+        canvas.drawText(title, x + s / 2, y + height + 26, labelPaint)
 
         if (isStunned) {
             canvas.drawText("*sees stars*", x + s / 2, y - 60, stunTextPaint)

--- a/app/src/main/java/com/escapegame/entities/Talmid.kt
+++ b/app/src/main/java/com/escapegame/entities/Talmid.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import com.escapegame.core.GameConfig
 import com.escapegame.model.Platform
+import kotlin.math.sin
 
 /**
  * The player: a young talmid making a break for it.
@@ -40,6 +41,10 @@ class Talmid {
         private set
     var invincibleFrames = 0
         private set
+
+    /** Per-level modifiers, set by the engine when a level loads. */
+    var frictionFactor = GameConfig.PLAYER_FRICTION
+    var windEnabled = false
 
     val isInvincible: Boolean get() = invincibleFrames > 0
 
@@ -95,13 +100,16 @@ class Talmid {
         invincibleFrames = 0
     }
 
-    fun jump() {
+    /** Returns true if a jump actually happened (for sound effects). */
+    fun jump(): Boolean {
         val maxJumps =
             if (seltzerFrames > 0) GameConfig.PLAYER_SELTZER_JUMPS else GameConfig.PLAYER_BASE_JUMPS
         if (jumpCount < maxJumps) {
             velocityY = GameConfig.PLAYER_JUMP_POWER
             jumpCount++
+            return true
         }
+        return false
     }
 
     fun moveLeft(isRunning: Boolean) {
@@ -166,10 +174,14 @@ class Talmid {
 
         velocityY += GameConfig.GRAVITY
         if (!running) {
-            velocityX *= GameConfig.PLAYER_FRICTION
+            velocityX *= frictionFactor
         }
 
         x += velocityX
+        if (windEnabled) {
+            // Gusts sway sinusoidally; strong enough to notice mid-jump
+            x += sin(animFrame * 0.02) .toFloat() * 2.4f
+        }
         if (x < 0f) {
             x = 0f
             velocityX = 0f

--- a/app/src/main/java/com/escapegame/levels/Levels.kt
+++ b/app/src/main/java/com/escapegame/levels/Levels.kt
@@ -2,6 +2,7 @@ package com.escapegame.levels
 
 import com.escapegame.model.LevelDefinition
 import com.escapegame.model.LevelTheme
+import com.escapegame.model.Modifier
 import com.escapegame.model.PatrollerSpec
 import com.escapegame.model.PlatformSpec
 import com.escapegame.model.PowerUpSpec
@@ -334,6 +335,186 @@ object Levels {
                 PatrollerSpec(0.30f, 0.75f, FLOOR_TOP),
                 PatrollerSpec(0.30f, 0.66f, T2)
             )
+        ),
+        LevelDefinition(
+            number = 13,
+            name = "The Coat Room",
+            quip = "Four hundred identical black coats. One is yours. There is no time to check.",
+            theme = LevelTheme.COAT_ROOM,
+            menahelSpeed = 6.8f,
+            platforms = listOf(
+                PlatformSpec(0.10f, T1, 0.18f),
+                PlatformSpec(0.40f, T2, 0.18f),
+                PlatformSpec(0.70f, T1, 0.18f),
+                PlatformSpec(0.24f, T3, 0.18f),
+                PlatformSpec(0.55f, T4, 0.18f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.19f, T1 - 0.04f),
+                RugelachSpec(0.49f, T2 - 0.04f),
+                RugelachSpec(0.79f, T1 - 0.04f),
+                RugelachSpec(0.33f, T3 - 0.04f),
+                RugelachSpec(0.64f, T4 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.05f, FLOOR_TOP - 0.045f, PowerUpType.COFFEE)
+            ),
+            patrollers = listOf(
+                PatrollerSpec(0.30f, 0.80f, FLOOR_TOP)
+            ),
+            modifiers = setOf(Modifier.DARK)
+        ),
+        LevelDefinition(
+            number = 14,
+            name = "The Mikveh (Erev Shabbos)",
+            quip = "The floor is wet. Obviously. The Menahel brought his good shoes anyway.",
+            theme = LevelTheme.MIKVEH,
+            menahelSpeed = 7.0f,
+            platforms = listOf(
+                PlatformSpec(0.08f, T1, 0.16f),
+                PlatformSpec(0.34f, T1, 0.16f),
+                PlatformSpec(0.60f, T1, 0.16f),
+                PlatformSpec(0.20f, T3, 0.16f),
+                PlatformSpec(0.48f, T3, 0.16f),
+                PlatformSpec(0.76f, T3, 0.16f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.16f, T1 - 0.04f),
+                RugelachSpec(0.42f, T1 - 0.04f),
+                RugelachSpec(0.68f, T1 - 0.04f),
+                RugelachSpec(0.28f, T3 - 0.04f),
+                RugelachSpec(0.56f, T3 - 0.04f),
+                RugelachSpec(0.84f, T3 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.90f, T3 - 0.09f, PowerUpType.KUGEL)
+            ),
+            modifiers = setOf(Modifier.SLIPPERY)
+        ),
+        LevelDefinition(
+            number = 15,
+            name = "The Fire-Escape Sukkah",
+            quip = "Halachically questionable. Structurally worse. The wind has opinions.",
+            theme = LevelTheme.SUKKAH,
+            menahelSpeed = 7.2f,
+            platforms = listOf(
+                PlatformSpec(0.10f, T1, 0.16f),
+                PlatformSpec(0.38f, T2, 0.16f),
+                PlatformSpec(0.66f, T3, 0.16f),
+                PlatformSpec(0.38f, T4, 0.16f),
+                PlatformSpec(0.10f, T5, 0.16f),
+                PlatformSpec(0.62f, T5, 0.16f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.18f, T1 - 0.04f),
+                RugelachSpec(0.46f, T2 - 0.04f),
+                RugelachSpec(0.74f, T3 - 0.04f),
+                RugelachSpec(0.46f, T4 - 0.04f),
+                RugelachSpec(0.18f, T5 - 0.04f),
+                RugelachSpec(0.70f, T5 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.05f, FLOOR_TOP - 0.045f, PowerUpType.SELTZER)
+            ),
+            patrollers = listOf(
+                PatrollerSpec(0.20f, 0.70f, FLOOR_TOP)
+            ),
+            modifiers = setOf(Modifier.WIND)
+        ),
+        LevelDefinition(
+            number = 16,
+            name = "The Shul Kiddush",
+            quip = "Herring, crackers, and nowhere to hide. The Assistant Menahel is also here.",
+            theme = LevelTheme.SHUL,
+            menahelSpeed = 7.4f,
+            platforms = listOf(
+                PlatformSpec(0.08f, T1, 0.16f),
+                PlatformSpec(0.34f, T2, 0.16f),
+                PlatformSpec(0.62f, T1, 0.16f),
+                PlatformSpec(0.84f, T3, 0.14f),
+                PlatformSpec(0.30f, T4, 0.16f),
+                PlatformSpec(0.58f, T5, 0.14f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.16f, T1 - 0.04f),
+                RugelachSpec(0.42f, T2 - 0.04f),
+                RugelachSpec(0.70f, T1 - 0.04f),
+                RugelachSpec(0.91f, T3 - 0.04f),
+                RugelachSpec(0.38f, T4 - 0.04f),
+                RugelachSpec(0.65f, T5 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.05f, FLOOR_TOP - 0.045f, PowerUpType.KUGEL)
+            ),
+            modifiers = setOf(Modifier.ASSISTANT_MENAHEL)
+        ),
+        LevelDefinition(
+            number = 17,
+            name = "The Simcha Hall",
+            quip = "A vort. Again. You don't even know whose. The dance floor was just polished.",
+            theme = LevelTheme.SIMCHA_HALL,
+            menahelSpeed = 7.6f,
+            platforms = listOf(
+                PlatformSpec(0.06f, T1, 0.15f),
+                PlatformSpec(0.30f, T2, 0.15f),
+                PlatformSpec(0.54f, T3, 0.15f),
+                PlatformSpec(0.78f, T2, 0.15f),
+                PlatformSpec(0.30f, T4, 0.15f),
+                PlatformSpec(0.06f, T5, 0.15f),
+                PlatformSpec(0.55f, T5, 0.15f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.13f, T1 - 0.04f),
+                RugelachSpec(0.37f, T2 - 0.04f),
+                RugelachSpec(0.61f, T3 - 0.04f),
+                RugelachSpec(0.85f, T2 - 0.04f),
+                RugelachSpec(0.37f, T4 - 0.04f),
+                RugelachSpec(0.13f, T5 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.90f, FLOOR_TOP - 0.045f, PowerUpType.COFFEE),
+                PowerUpSpec(0.62f, T5 - 0.09f, PowerUpType.KUGEL)
+            ),
+            patrollers = listOf(
+                PatrollerSpec(0.30f, 0.75f, FLOOR_TOP)
+            ),
+            modifiers = setOf(Modifier.SLIPPERY, Modifier.ASSISTANT_MENAHEL)
+        ),
+        LevelDefinition(
+            number = 18,
+            name = "The Mesivta Van",
+            quip = "The van to the mountains leaves NOW. Everyone is watching. NU, GO!",
+            theme = LevelTheme.BUS_STOP,
+            menahelSpeed = 7.9f,
+            platforms = listOf(
+                PlatformSpec(0.06f, T1, 0.14f),
+                PlatformSpec(0.28f, T2, 0.14f),
+                PlatformSpec(0.50f, T3, 0.14f),
+                PlatformSpec(0.72f, T2, 0.14f),
+                PlatformSpec(0.28f, T4, 0.14f),
+                PlatformSpec(0.06f, T5, 0.14f),
+                PlatformSpec(0.52f, T5, 0.14f),
+                PlatformSpec(0.76f, T4, 0.14f)
+            ),
+            rugelach = listOf(
+                RugelachSpec(0.12f, T1 - 0.04f),
+                RugelachSpec(0.34f, T2 - 0.04f),
+                RugelachSpec(0.56f, T3 - 0.04f),
+                RugelachSpec(0.78f, T2 - 0.04f),
+                RugelachSpec(0.34f, T4 - 0.04f),
+                RugelachSpec(0.12f, T5 - 0.04f),
+                RugelachSpec(0.58f, T5 - 0.04f),
+                RugelachSpec(0.82f, T4 - 0.04f)
+            ),
+            powerUps = listOf(
+                PowerUpSpec(0.90f, FLOOR_TOP - 0.045f, PowerUpType.COFFEE),
+                PowerUpSpec(0.05f, FLOOR_TOP - 0.045f, PowerUpType.SELTZER)
+            ),
+            patrollers = listOf(
+                PatrollerSpec(0.28f, 0.70f, FLOOR_TOP)
+            ),
+            modifiers = setOf(Modifier.ASSISTANT_MENAHEL),
+            timeLimitSeconds = 75
         )
     )
 
@@ -356,7 +537,13 @@ object Levels {
         "Mamash unbelievable!",
         "Wait till I call your father!",
         "The Rosh Yeshiva will hear of this!",
-        "You call that a gartel?!"
+        "You call that a gartel?!",
+        "Bittul zman! BITTUL ZMAN!",
+        "You think this is camp?!",
+        "Not in MY yeshiva!",
+        "Who gave you a heter?!",
+        "That felafel comes out of recess!",
+        "I know your chavrusa's father!"
     )
 
     /** Random headline for the game-over screen. */
@@ -367,7 +554,10 @@ object Levels {
         "Nu nu. Back to seder.",
         "Oy vey. So close.",
         "He gave you the LOOK. It's over.",
-        "Straight to mussar shmuess with you."
+        "Straight to mussar shmuess with you.",
+        "The Assistant Menahel saw everything. Twice.",
+        "Your father was called. And your zeidy.",
+        "Verdict: chutzpah in the first degree."
     )
 
     /** Lines for the victory screen, in display order. */

--- a/app/src/main/java/com/escapegame/model/GameModels.kt
+++ b/app/src/main/java/com/escapegame/model/GameModels.kt
@@ -22,7 +22,12 @@ enum class LevelTheme {
     DETENTION,
     ROOFTOP,
     PARKING_LOT,
-    BUS_STOP
+    BUS_STOP,
+    COAT_ROOM,
+    MIKVEH,
+    SUKKAH,
+    SHUL,
+    SIMCHA_HALL
 }
 
 /** Power-up varieties and their on-screen labels. */
@@ -30,6 +35,14 @@ enum class PowerUpType(val label: String) {
     COFFEE("KAVANA COFFEE! Speed boost!"),
     SELTZER("SELTZER! Triple jump!"),
     KUGEL("KUGEL SHIELD! One free catch!")
+}
+
+/** Per-level gameplay twists, announced on the level card. */
+enum class Modifier(val announcement: String) {
+    SLIPPERY("WET FLOOR! No traction!"),
+    DARK("LIGHTS OUT! Stay close to your ner!"),
+    WIND("WINDY! Hold onto your hat!"),
+    ASSISTANT_MENAHEL("TWO MENAHELIM?! Oy!")
 }
 
 /** A solid platform in world (pixel) coordinates. */
@@ -64,5 +77,8 @@ data class LevelDefinition(
     val platforms: List<PlatformSpec>,
     val rugelach: List<RugelachSpec>,
     val powerUps: List<PowerUpSpec> = emptyList(),
-    val patrollers: List<PatrollerSpec> = emptyList()
+    val patrollers: List<PatrollerSpec> = emptyList(),
+    val modifiers: Set<Modifier> = emptySet(),
+    /** If set, the level must be finished before the van leaves. */
+    val timeLimitSeconds: Int? = null
 )

--- a/app/src/main/java/com/escapegame/render/BackgroundRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/BackgroundRenderer.kt
@@ -53,7 +53,8 @@ class BackgroundRenderer(private val w: Float, private val h: Float) {
     private fun drawWallsAndFloor(canvas: Canvas, theme: LevelTheme) {
         val outdoors = theme == LevelTheme.ROOFTOP ||
             theme == LevelTheme.PARKING_LOT ||
-            theme == LevelTheme.BUS_STOP
+            theme == LevelTheme.BUS_STOP ||
+            theme == LevelTheme.SUKKAH
 
         fillPaint.color = when (theme) {
             LevelTheme.LUNCHROOM -> Color.rgb(240, 240, 220)
@@ -67,6 +68,11 @@ class BackgroundRenderer(private val w: Float, private val h: Float) {
             LevelTheme.ROOFTOP -> Color.rgb(160, 210, 245)
             LevelTheme.PARKING_LOT -> Color.rgb(175, 215, 240)
             LevelTheme.BUS_STOP -> Color.rgb(255, 205, 150) // late-afternoon sky
+            LevelTheme.COAT_ROOM -> Color.rgb(205, 200, 190)
+            LevelTheme.MIKVEH -> Color.rgb(195, 225, 235)
+            LevelTheme.SUKKAH -> Color.rgb(150, 205, 240)
+            LevelTheme.SHUL -> Color.rgb(238, 232, 214)
+            LevelTheme.SIMCHA_HALL -> Color.rgb(242, 235, 245)
         }
         canvas.drawRect(0f, 0f, w, h, fillPaint)
 
@@ -229,6 +235,98 @@ class BackgroundRenderer(private val w: Float, private val h: Float) {
                 textPaint.color = Color.BLACK
                 textPaint.textSize = 30f
                 canvas.drawText("4:15 EXPRESS", 710f, 275f, textPaint)
+            }
+            LevelTheme.COAT_ROOM -> {
+                // A rack of four hundred identical black coats
+                strokePaint.color = Color.rgb(90, 90, 95)
+                canvas.drawLine(60f, 180f, w - 60f, 180f, strokePaint)
+                fillPaint.color = Color.rgb(20, 20, 24)
+                var cx = 90f
+                while (cx < w - 120f) {
+                    canvas.drawCircle(cx + 30f, 192f, 7f, fillPaint) // hanger hook
+                    canvas.drawRect(cx, 205f, cx + 62f, 420f, fillPaint)
+                    cx += 74f
+                }
+                drawWallSign(canvas, w / 2, 520f, "LOST & NEVER FOUND")
+            }
+            LevelTheme.MIKVEH -> {
+                // Tiled wall
+                strokePaint.color = Color.rgb(140, 180, 195)
+                var ty = 140f
+                while (ty < 460f) {
+                    canvas.drawLine(60f, ty, w - 60f, ty, strokePaint)
+                    ty += 64f
+                }
+                var tx2 = 60f
+                while (tx2 < w - 60f) {
+                    canvas.drawLine(tx2, 140f, tx2, 460f, strokePaint)
+                    tx2 += 64f
+                }
+                // Towel hooks with towels
+                fillPaint.color = Color.WHITE
+                canvas.drawRect(150f, 240f, 220f, 400f, fillPaint)
+                canvas.drawRect(300f, 240f, 370f, 400f, fillPaint)
+                // Puddles by the floor
+                fillPaint.color = Color.rgb(160, 205, 225)
+                canvas.drawOval(180f, floorTop - 18f, 360f, floorTop + 4f, fillPaint)
+                canvas.drawOval(520f, floorTop - 14f, 660f, floorTop + 2f, fillPaint)
+                drawWallSign(canvas, w / 2, 540f, "NO RUNNING (WET FLOOR)")
+            }
+            LevelTheme.SUKKAH -> {
+                // Schach across the top
+                fillPaint.color = Color.rgb(90, 140, 60)
+                var sx = 0f
+                while (sx < w) {
+                    canvas.drawRect(sx, 60f, sx + 70f, 130f, fillPaint)
+                    sx += 90f
+                }
+                // Wooden walls at the sides
+                fillPaint.color = Color.rgb(150, 105, 55)
+                canvas.drawRect(0f, 130f, 70f, floorTop, fillPaint)
+                canvas.drawRect(w - 70f, 130f, w, floorTop, fillPaint)
+                // Paper-chain decorations hanging from the schach
+                strokePaint.color = Color.rgb(90, 140, 60)
+                canvas.drawLine(220f, 130f, 220f, 250f, strokePaint)
+                canvas.drawLine(w / 2, 130f, w / 2, 300f, strokePaint)
+                fillPaint.color = Color.rgb(210, 60, 60)
+                canvas.drawCircle(220f, 270f, 20f, fillPaint)
+                fillPaint.color = Color.rgb(60, 110, 210)
+                canvas.drawCircle(w / 2, 320f, 20f, fillPaint)
+                drawWallSign(canvas, w - 260f, 250f, "NOI SUKKAH 5747")
+            }
+            LevelTheme.SHUL -> {
+                // The aron with its paroches
+                fillPaint.color = Color.rgb(90, 30, 40)
+                canvas.drawRect(w / 2 - 140f, 150f, w / 2 + 140f, 430f, fillPaint)
+                strokePaint.color = Color.rgb(220, 190, 90)
+                canvas.drawRect(w / 2 - 140f, 150f, w / 2 + 140f, 430f, strokePaint)
+                canvas.drawLine(w / 2, 150f, w / 2, 430f, strokePaint)
+                // Stained-glass windows
+                fillPaint.color = Color.rgb(120, 160, 220)
+                canvas.drawOval(120f, 160f, 240f, 340f, fillPaint)
+                canvas.drawOval(w - 240f, 160f, w - 120f, 340f, fillPaint)
+                fillPaint.color = Color.rgb(220, 160, 90)
+                canvas.drawOval(150f, 200f, 210f, 300f, fillPaint)
+                canvas.drawOval(w - 210f, 200f, w - 150f, 300f, fillPaint)
+                drawWallSign(canvas, w / 2, 520f, "KIDDUSH SPONSORED ANONYMOUSLY")
+            }
+            LevelTheme.SIMCHA_HALL -> {
+                // Chandelier
+                strokePaint.color = Color.rgb(190, 160, 60)
+                canvas.drawLine(w / 2, 60f, w / 2, 160f, strokePaint)
+                fillPaint.color = Color.rgb(245, 225, 130)
+                canvas.drawCircle(w / 2, 190f, 45f, fillPaint)
+                canvas.drawCircle(w / 2 - 70f, 210f, 22f, fillPaint)
+                canvas.drawCircle(w / 2 + 70f, 210f, 22f, fillPaint)
+                // Round tables with white cloths
+                fillPaint.color = Color.WHITE
+                canvas.drawOval(90f, floorTop - 90f, 300f, floorTop - 20f, fillPaint)
+                canvas.drawOval(w - 300f, floorTop - 90f, w - 90f, floorTop - 20f, fillPaint)
+                // Flowers on the tables
+                fillPaint.color = Color.rgb(220, 90, 140)
+                canvas.drawCircle(195f, floorTop - 95f, 12f, fillPaint)
+                canvas.drawCircle(w - 195f, floorTop - 95f, 12f, fillPaint)
+                drawWallSign(canvas, w / 2, 320f, "MAZEL TOV! (WHOSE? UNCLEAR)")
             }
         }
     }

--- a/app/src/main/java/com/escapegame/render/HudRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/HudRenderer.kt
@@ -33,12 +33,26 @@ class HudRenderer(private val w: Float) {
         textSize = 26f
         style = Paint.Style.FILL
     }
+    private val vanPaint = Paint().apply {
+        textSize = 34f
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+        style = Paint.Style.FILL
+    }
     private val barPaint = Paint().apply {
         color = Color.argb(140, 255, 255, 255)
         style = Paint.Style.FILL
     }
 
-    fun draw(canvas: Canvas, score: Int, highScore: Int, lives: Int, level: LevelDefinition, talmid: Talmid) {
+    fun draw(
+        canvas: Canvas,
+        score: Int,
+        highScore: Int,
+        lives: Int,
+        level: LevelDefinition,
+        talmid: Talmid,
+        vanSecondsLeft: Int?
+    ) {
         // Translucent strip so the HUD stays readable over any theme
         canvas.drawRect(0f, 0f, w, 116f, barPaint)
 
@@ -47,6 +61,12 @@ class HudRenderer(private val w: Float) {
         canvas.drawText("Score: $score", 20f, 88f, textPaint)
         rightTextPaint.color = Color.rgb(90, 60, 20)
         canvas.drawText("Best: $highScore", w - 20f, 44f, rightTextPaint)
+
+        if (vanSecondsLeft != null) {
+            vanPaint.color =
+                if (vanSecondsLeft <= 10) Color.rgb(220, 30, 30) else Color.rgb(150, 60, 10)
+            canvas.drawText("VAN LEAVES: ${vanSecondsLeft}s", w / 2, 88f, vanPaint)
+        }
 
         // Lives as black hats, top right
         for (i in 0 until lives) {

--- a/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
@@ -63,6 +63,12 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
         textSize = 26f
         textAlign = Paint.Align.CENTER
     }
+    private val modifierPaint = Paint().apply {
+        color = Color.rgb(255, 170, 60)
+        textSize = 28f
+        textAlign = Paint.Align.CENTER
+        typeface = Typeface.DEFAULT_BOLD
+    }
     private val cardRect = RectF()
 
     fun drawIntro(canvas: Canvas, highScore: Int) {
@@ -77,7 +83,7 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
             canvas.drawText("D-pad — move  ·  B — jump (x2 = double)", w / 2, y, bodyPaint); y += lh
             canvas.drawText("A — run + shoot felafel", w / 2, y, bodyPaint); y += lh
             canvas.drawText("START — mincha break (pause)", w / 2, y, bodyPaint); y += lh * 1.4f
-            canvas.drawText("Grab rugelach. 12 levels to the 4:15 bus.", w / 2, y, bodyPaint)
+            canvas.drawText("Grab rugelach. ${Levels.all.size} levels to freedom.", w / 2, y, bodyPaint)
 
             if (highScore > 0) {
                 canvas.drawText("Best escape so far: $highScore", w / 2, h * 0.76f, bodyPaint)
@@ -103,7 +109,7 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
         canvas.drawText("0 / # — klezmer on/off", w / 2, y, bodyPaint); y += lh * 1.8f
 
         canvas.drawText("Grab rugelach. Chap the power-ups.", w / 2, y, bodyPaint); y += lh
-        canvas.drawText("12 levels between you and the 4:15 bus.", w / 2, y, bodyPaint); y += lh * 1.6f
+        canvas.drawText("${Levels.all.size} levels between you and freedom.", w / 2, y, bodyPaint); y += lh * 1.6f
 
         if (highScore > 0) {
             canvas.drawText("Best escape so far: $highScore", w / 2, y, bodyPaint)
@@ -125,10 +131,20 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
 
         val top = cardRect.top
         val height = cardRect.height()
-        canvas.drawText("Level ${level.number} of ${Levels.all.size}", w / 2, top + height * 0.18f, bodyPaint)
-        canvas.drawText(level.name, w / 2, top + height * 0.36f, headerPaint)
-        drawWrapped(canvas, level.quip, w / 2, top + height * 0.55f, cardRect.width() * 0.86f)
-        canvas.drawText(confirmPrompt("go"), w / 2, cardRect.bottom - height * 0.1f, accentPaint)
+        canvas.drawText("Level ${level.number} of ${Levels.all.size}", w / 2, top + height * 0.16f, bodyPaint)
+        canvas.drawText(level.name, w / 2, top + height * 0.32f, headerPaint)
+        drawWrapped(canvas, level.quip, w / 2, top + height * 0.47f, cardRect.width() * 0.86f)
+
+        var modifierY = top + height * 0.68f
+        for (modifier in level.modifiers) {
+            canvas.drawText(modifier.announcement, w / 2, modifierY, modifierPaint)
+            modifierY += 34f
+        }
+        level.timeLimitSeconds?.let {
+            canvas.drawText("THE VAN LEAVES IN $it SECONDS!", w / 2, modifierY, modifierPaint)
+        }
+
+        canvas.drawText(confirmPrompt("go"), w / 2, cardRect.bottom - height * 0.08f, accentPaint)
     }
 
     fun drawPaused(canvas: Canvas) {


### PR DESCRIPTION
## What changed

### Six new levels (18 total)
13. **The Coat Room** — lights out; four hundred identical black coats
14. **The Mikveh (Erev Shabbos)** — wet floor, no traction
15. **The Fire-Escape Sukkah** — wind gusts, halachically questionable
16. **The Shul Kiddush** — the Assistant Menahel joins the chase
17. **The Simcha Hall** — polished dance floor **and** the assistant
18. **The Mesivta Van** — the van leaves in 75 seconds; countdown in the HUD

Each with a new themed backdrop (coat rack, tiled mikveh with puddles, sukkah with schach + paper chains, shul with aron and stained glass, simcha hall with chandelier and vort tables).

### Modifier system
`Modifier` set per level, announced on the level card: SLIPPERY, DARK (circle-of-light rendering via one preallocated stroked ring), WIND (sinusoidal gusts), ASSISTANT_MENAHEL (second chaser, slower but starts closer), plus an optional `timeLimitSeconds` (lose a life when the van leaves, clock resets).

### Sound effects
Jump blip, felafel pfft, pickup ding, power-up arpeggio, stun FM warble, caught womp, level-clear fanfare — synthesized one-shot voices mixed into the existing music stream through a concurrent queue. Still zero audio assets.

### More mussar
Six new Menahel quotes, three new game-over lines; intro text derives the level count.

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_