### PR TITLE
Chalk attacks, semicha achievements, PA announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ between you and the 4:15 bus to freedom.
 - **Rugelach collectibles**, score with time bonuses, 3 lives (displayed as
   black hats, naturally), and a persistent high score
 - **Pause = Mincha Break**
+- **Chalk fire** — from level 10 the Menahel throws chalk with decades-honed
+  accuracy; getting hit delivers mussar (half speed while you absorb it)
+- **Semichos (achievements)** — five lifetime achievements (Felafel Sniper,
+  Zrizus, Kibud Rugelach, Shomer Nafsho, and full Semicha in Escapology)
+  plus lifetime escape stats, persisted across launches
+- **PA announcements** — the yeshiva intercom interrupts at random
+  ("Reminder — the elevator is still fleishig.")
 - **Funky klezmer chiptune soundtrack + sound effects** — a D-freygish loop
   and all SFX (jump blips, felafel pfft, pickup dings, stun warbles, caught
   womps, level fanfares) synthesized at runtime, zero audio assets. Mute

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
 import com.escapegame.core.GameConfig
+import com.escapegame.entities.Chalk
 import com.escapegame.entities.FelafelBall
 import com.escapegame.entities.Mashgiach
 import com.escapegame.entities.Menahel
@@ -12,6 +13,7 @@ import com.escapegame.entities.PowerUp
 import com.escapegame.entities.Rugelach
 import com.escapegame.entities.Talmid
 import com.escapegame.levels.Levels
+import com.escapegame.model.Achievement
 import com.escapegame.model.GamePhase
 import com.escapegame.model.Modifier
 import com.escapegame.model.LevelDefinition
@@ -57,6 +59,7 @@ class GameEngine(
     private val mashgichim = mutableListOf<Mashgiach>()
     private val platforms = mutableListOf<Platform>()
     private val felafelBalls = mutableListOf<FelafelBall>()
+    private val chalks = mutableListOf<Chalk>()
     private val rugelach = mutableListOf<Rugelach>()
     private val powerUps = mutableListOf<PowerUp>()
     private val floatingTexts = mutableListOf<FloatingText>()
@@ -69,6 +72,12 @@ class GameEngine(
     private var phaseFrames = 0
     /** Frames until the van leaves without you; -1 when the level has no timer. */
     private var vanFrames = -1
+    private var chalkCooldown = 300
+    private var runLivesLost = 0
+    // PA announcement state
+    private var paCooldown = 1600
+    private var paText: String? = null
+    private var paFrames = 0
     private var highScore = prefs.getHighScore()
     private var newBest = false
     private var gameOverLine = Levels.gameOverLines.first()
@@ -122,6 +131,16 @@ class GameEngine(
         color = Color.argb(233, 5, 5, 14)
         style = Paint.Style.STROKE
         strokeWidth = 4200f
+    }
+    private val paBannerPaint = Paint().apply {
+        color = Color.argb(190, 20, 20, 30)
+        style = Paint.Style.FILL
+    }
+    private val paTextPaint = Paint().apply {
+        color = Color.rgb(255, 240, 180)
+        textSize = 26f
+        textAlign = Paint.Align.CENTER
+        style = Paint.Style.FILL
     }
 
     // ---------------------------------------------------------------- input
@@ -187,6 +206,7 @@ class GameEngine(
         score = 0
         lives = GameConfig.STARTING_LIVES
         newBest = false
+        runLivesLost = 0
         talmid.clearEffects()
         loadLevel(0)
     }
@@ -280,6 +300,10 @@ class GameEngine(
             if (Modifier.SLIPPERY in level.modifiers) 0.975f else GameConfig.PLAYER_FRICTION
         talmid.windEnabled = Modifier.WIND in level.modifiers
         vanFrames = level.timeLimitSeconds?.times(60) ?: -1
+        chalks.clear()
+        chalkCooldown = 300 + Random.nextInt(180)
+        paText = null
+        paCooldown = 1200 + Random.nextInt(1200)
 
         levelFrames = 0
         phaseFrames = 0
@@ -328,11 +352,58 @@ class GameEngine(
             }
         }
 
+        updateChalk()
+        updateAnnouncements()
         updateFelafel()
         updatePickups()
         updateFloatingTexts()
         checkCatches()
         checkExit()
+    }
+
+    /** From level 10 the Menahel throws chalk with decades-honed accuracy. */
+    private fun updateChalk() {
+        if (level.number >= 10 && !menahel.isStunned) {
+            chalkCooldown--
+            if (chalkCooldown <= 0) {
+                chalkCooldown = 240 + Random.nextInt(200)
+                val direction = if (talmid.centerX > menahel.centerX) 1f else -1f
+                chalks.add(Chalk(menahel.centerX, menahel.y, direction * (6f + Random.nextFloat() * 3f)))
+            }
+        }
+        val iterator = chalks.iterator()
+        while (iterator.hasNext()) {
+            val chalk = iterator.next()
+            chalk.update(worldWidth, floorTop)
+            if (!chalk.active) {
+                iterator.remove()
+                continue
+            }
+            if (!talmid.isInvincible && talmid.mussarFrames == 0 &&
+                chalk.hits(talmid.centerX, talmid.centerY, 42f)
+            ) {
+                talmid.receiveMussar()
+                music.playSfx(Sfx.STUN)
+                addFloatingText("GOT MUSSAR'D! Slowed!", talmid.centerX, talmid.y - 70f, Color.rgb(180, 60, 60))
+                iterator.remove()
+            }
+        }
+    }
+
+    private fun updateAnnouncements() {
+        if (paFrames > 0) {
+            paFrames--
+            if (paFrames == 0) {
+                paText = null
+                paCooldown = 1500 + Random.nextInt(1200)
+            }
+        } else {
+            paCooldown--
+            if (paCooldown <= 0) {
+                paText = Levels.paAnnouncements[Random.nextInt(Levels.paAnnouncements.size)]
+                paFrames = 300
+            }
+        }
     }
 
     private fun updateFelafel() {
@@ -346,7 +417,7 @@ class GameEngine(
             }
             if (ball.hits(menahel.centerX, menahel.centerY, GameConfig.MENAHEL_CATCH_DISTANCE)) {
                 menahel.stun()
-                music.playSfx(Sfx.STUN)
+                recordStun()
                 addFloatingText("BULLSEYE!", menahel.centerX, menahel.y - 40f, Color.rgb(255, 160, 40))
                 iterator.remove()
                 continue
@@ -357,7 +428,7 @@ class GameEngine(
                     ball.hits(a.centerX, a.centerY, GameConfig.MENAHEL_CATCH_DISTANCE)
                 ) {
                     a.stun()
-                    music.playSfx(Sfx.STUN)
+                    recordStun()
                     addFloatingText("Also him!", a.centerX, a.y - 40f, Color.rgb(255, 160, 40))
                     hitAssistant = true
                     break
@@ -373,7 +444,7 @@ class GameEngine(
                     ball.hits(m.centerX, m.centerY, GameConfig.MASHGIACH_CATCH_DISTANCE)
                 ) {
                     m.stun()
-                    music.playSfx(Sfx.STUN)
+                    recordStun()
                     addFloatingText("Lost his place!", m.centerX, m.y - 40f, Color.rgb(255, 160, 40))
                     hitPatroller = true
                     break
@@ -464,6 +535,7 @@ class GameEngine(
     private fun loseLife(message: String) {
         music.playSfx(Sfx.CAUGHT)
         lives--
+        runLivesLost++
         if (lives <= 0) {
             gameOverLine = Levels.gameOverLines[Random.nextInt(Levels.gameOverLines.size)]
             newBest = prefs.submitScore(score)
@@ -492,7 +564,15 @@ class GameEngine(
         score += GameConfig.SCORE_LEVEL_CLEAR + timeBonus
         music.playSfx(Sfx.LEVEL_CLEAR)
 
+        if (seconds < 15) award(Achievement.ZRIZUS)
+        if (rugelach.isNotEmpty() && rugelach.all { it.collected }) {
+            award(Achievement.KIBUD_RUGELACH)
+        }
+
         if (levelIndex + 1 >= Levels.all.size) {
+            award(Achievement.SEMICHA)
+            if (runLivesLost == 0) award(Achievement.SHOMER_NAFSHO)
+            prefs.incrementCounter("escapes")
             newBest = prefs.submitScore(score)
             if (newBest) highScore = score
             phase = GamePhase.VICTORY
@@ -502,10 +582,27 @@ class GameEngine(
         }
     }
 
+    private fun recordStun() {
+        music.playSfx(Sfx.STUN)
+        if (prefs.incrementCounter("stuns") >= 25) {
+            award(Achievement.FELAFEL_SNIPER)
+        }
+    }
+
+    /** Grants a semicha (achievement) once, with a golden banner. */
+    private fun award(achievement: Achievement) {
+        if (prefs.isAchieved(achievement.name)) return
+        prefs.setAchieved(achievement.name)
+        addFloatingText(
+            achievement.title,
+            worldWidth / 2, worldHeight * 0.35f, Color.rgb(255, 200, 40), 260
+        )
+    }
+
     // -------------------------------------------------------- floating text
 
-    private fun addFloatingText(text: String, x: Float, y: Float, color: Int) {
-        floatingTexts.add(FloatingText(text, x, y, color))
+    private fun addFloatingText(text: String, x: Float, y: Float, color: Int, frames: Int = 90) {
+        floatingTexts.add(FloatingText(text, x, y, color, frames))
     }
 
     private fun updateFloatingTexts() {
@@ -563,6 +660,7 @@ class GameEngine(
             for (a in assistants) a.draw(canvas, worldWidth)
             talmid.draw(canvas)
             for (ball in felafelBalls) ball.draw(canvas)
+            for (chalk in chalks) chalk.draw(canvas)
             for (t in floatingTexts) {
                 floatingTextPaint.color = t.color
                 canvas.drawText(t.text, t.x, t.y, floatingTextPaint)
@@ -576,6 +674,10 @@ class GameEngine(
             }
             val vanSeconds = if (vanFrames >= 0) (vanFrames + 59) / 60 else null
             hud.draw(canvas, score, highScore, lives, level, talmid, vanSeconds)
+            paText?.let { announcement ->
+                canvas.drawRect(worldWidth * 0.04f, 128f, worldWidth * 0.96f, 172f, paBannerPaint)
+                canvas.drawText(announcement, worldWidth / 2, 158f, paTextPaint)
+            }
             if (!touchControlsEnabled) {
                 hud.drawControlsHint(canvas, worldHeight)
             }
@@ -583,7 +685,11 @@ class GameEngine(
 
         overlay.touchMode = touchControlsEnabled
         when (phase) {
-            GamePhase.INTRO -> overlay.drawIntro(canvas, highScore)
+            GamePhase.INTRO -> overlay.drawIntro(
+                canvas, highScore,
+                Achievement.values().count { prefs.isAchieved(it.name) },
+                prefs.getCounter("escapes")
+            )
             GamePhase.LEVEL_INTRO -> overlay.drawLevelIntro(canvas, level)
             GamePhase.PAUSED -> overlay.drawPaused(canvas)
             GamePhase.GAME_OVER -> overlay.drawGameOver(canvas, gameOverLine, score, highScore, newBest)

--- a/app/src/main/java/com/escapegame/entities/Chalk.kt
+++ b/app/src/main/java/com/escapegame/entities/Chalk.kt
@@ -1,0 +1,55 @@
+package com.escapegame.entities
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+
+/**
+ * A piece of chalk, lobbed by the Menahel with uncanny accuracy honed over
+ * decades of waking up dozing bochurim from thirty feet. Getting hit doesn't
+ * cost a life — it delivers mussar, which slows you down while you absorb it.
+ */
+class Chalk(
+    private var x: Float,
+    private var y: Float,
+    private val velocityX: Float
+) {
+    private var velocityY = -7.5f
+    var active = true
+        private set
+
+    private val chalkPaint = Paint().apply { color = Color.WHITE; style = Paint.Style.FILL }
+    private val edgePaint = Paint().apply {
+        color = Color.rgb(200, 200, 205)
+        strokeWidth = 2f
+        style = Paint.Style.STROKE
+    }
+
+    fun update(worldWidth: Float, floorTopY: Float) {
+        if (!active) return
+        x += velocityX
+        velocityY += 0.55f
+        y += velocityY
+        if (y > floorTopY || x < -20f || x > worldWidth + 20f) {
+            active = false
+        }
+    }
+
+    fun draw(canvas: Canvas) {
+        if (!active) return
+        canvas.drawRect(x - 9f, y - 4f, x + 9f, y + 4f, chalkPaint)
+        canvas.drawRect(x - 9f, y - 4f, x + 9f, y + 4f, edgePaint)
+    }
+
+    /** True if this (active) chalk is within [hitDistance] of the given center. */
+    fun hits(targetCenterX: Float, targetCenterY: Float, hitDistance: Float): Boolean {
+        if (!active) return false
+        val dx = x - targetCenterX
+        val dy = y - targetCenterY
+        if (dx * dx + dy * dy < hitDistance * hitDistance) {
+            active = false
+            return true
+        }
+        return false
+    }
+}

--- a/app/src/main/java/com/escapegame/entities/Talmid.kt
+++ b/app/src/main/java/com/escapegame/entities/Talmid.kt
@@ -46,6 +46,10 @@ class Talmid {
     var frictionFactor = GameConfig.PLAYER_FRICTION
     var windEnabled = false
 
+    /** Frames left of absorbing a chalk-delivered mussar shmuess (half speed). */
+    var mussarFrames = 0
+        private set
+
     val isInvincible: Boolean get() = invincibleFrames > 0
 
     private val suitPaint = Paint().apply { color = Color.rgb(40, 40, 40); style = Paint.Style.FILL }
@@ -91,6 +95,7 @@ class Talmid {
     fun respawn(startX: Float, floorTopY: Float) {
         resetForLevel(startX, floorTopY)
         invincibleFrames = GameConfig.RESPAWN_INVINCIBILITY
+        mussarFrames = 0
     }
 
     fun clearEffects() {
@@ -129,8 +134,15 @@ class Talmid {
     }
 
     private fun currentSpeed(isRunning: Boolean): Float {
-        val base = if (isRunning) GameConfig.PLAYER_RUN_SPEED else GameConfig.PLAYER_WALK_SPEED
-        return if (coffeeFrames > 0) base * GameConfig.COFFEE_SPEED_MULTIPLIER else base
+        var speed = if (isRunning) GameConfig.PLAYER_RUN_SPEED else GameConfig.PLAYER_WALK_SPEED
+        if (coffeeFrames > 0) speed *= GameConfig.COFFEE_SPEED_MULTIPLIER
+        if (mussarFrames > 0) speed *= 0.5f
+        return speed
+    }
+
+    /** A chalk hit landed: absorb the mussar at half speed for two seconds. */
+    fun receiveMussar() {
+        mussarFrames = 120
     }
 
     /** Returns a felafel ball if the cooldown allows, else null. */
@@ -171,6 +183,7 @@ class Talmid {
         if (coffeeFrames > 0) coffeeFrames--
         if (seltzerFrames > 0) seltzerFrames--
         if (invincibleFrames > 0) invincibleFrames--
+        if (mussarFrames > 0) mussarFrames--
 
         velocityY += GameConfig.GRAVITY
         if (!running) {
@@ -258,6 +271,13 @@ class Talmid {
         // Shoes
         canvas.drawOval(x + 3, y + height - 11, x + 24, y + height + 4, shoePaint)
         canvas.drawOval(x + s - 24, y + height - 11, x + s - 3, y + height + 4, shoePaint)
+
+        // Absorbing mussar: a little gray cloud of rebuke overhead
+        if (mussarFrames > 0) {
+            canvas.drawCircle(x + s / 2 - 14, y - 58, 12f, glassesPaint)
+            canvas.drawCircle(x + s / 2, y - 64, 15f, glassesPaint)
+            canvas.drawCircle(x + s / 2 + 14, y - 58, 12f, glassesPaint)
+        }
 
         // Kugel shield: golden aura
         if (shieldCharges > 0) {

--- a/app/src/main/java/com/escapegame/levels/Levels.kt
+++ b/app/src/main/java/com/escapegame/levels/Levels.kt
@@ -560,6 +560,20 @@ object Levels {
         "Verdict: chutzpah in the first degree."
     )
 
+    /** PA-system announcements that interrupt gameplay at random. */
+    val paAnnouncements: List<String> = listOf(
+        "PA: Mincha in the small beis medrash in 5 minutes.",
+        "PA: Whoever borrowed the shtender from Room 2 - we know.",
+        "PA: Lost: one black hat. Description: black.",
+        "PA: The kiddush is BYOH. Bring your own herring.",
+        "PA: Night seder attendance will be VERY noted.",
+        "PA: The candy man retired. There is no replacement.",
+        "PA: Reminder - the elevator is still fleishig.",
+        "PA: The Menahel requests you stop running. Immediately.",
+        "PA: Supper is potato. Just potato.",
+        "PA: The coffee room is closed for chometz. It is Cheshvan."
+    )
+
     /** Lines for the victory screen, in display order. */
     val victoryLines: List<String> = listOf(
         "You escaped the yeshiva!",

--- a/app/src/main/java/com/escapegame/model/GameModels.kt
+++ b/app/src/main/java/com/escapegame/model/GameModels.kt
@@ -45,6 +45,15 @@ enum class Modifier(val announcement: String) {
     ASSISTANT_MENAHEL("TWO MENAHELIM?! Oy!")
 }
 
+/** Lifetime achievements — "semichos" — persisted across launches. */
+enum class Achievement(val title: String) {
+    SEMICHA("SEMICHA IN ESCAPOLOGY! Finished all 18 levels"),
+    FELAFEL_SNIPER("FELAFEL SNIPER! 25 lifetime stuns"),
+    ZRIZUS("ZRIZUS! Cleared a level in under 15 seconds"),
+    KIBUD_RUGELACH("KIBUD RUGELACH! Every rugelach in one level"),
+    SHOMER_NAFSHO("SHOMER NAFSHO! Escaped without losing a hat")
+}
+
 /** A solid platform in world (pixel) coordinates. */
 data class Platform(val x: Float, val y: Float, val width: Float, val height: Float)
 

--- a/app/src/main/java/com/escapegame/persistence/GamePrefs.kt
+++ b/app/src/main/java/com/escapegame/persistence/GamePrefs.kt
@@ -25,6 +25,21 @@ class GamePrefs(context: Context) {
         prefs.edit().putBoolean(KEY_MUTED, muted).apply()
     }
 
+    fun isAchieved(name: String): Boolean = prefs.getBoolean("ach_" + name, false)
+
+    fun setAchieved(name: String) {
+        prefs.edit().putBoolean("ach_" + name, true).apply()
+    }
+
+    fun getCounter(name: String): Int = prefs.getInt("cnt_" + name, 0)
+
+    /** Increments a lifetime counter and returns the new value. */
+    fun incrementCounter(name: String): Int {
+        val value = getCounter(name) + 1
+        prefs.edit().putInt("cnt_" + name, value).apply()
+        return value
+    }
+
     private companion object {
         const val PREFS_NAME = "escape_menahel"
         const val KEY_HIGH_SCORE = "high_score"

--- a/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
@@ -71,7 +71,7 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
     }
     private val cardRect = RectF()
 
-    fun drawIntro(canvas: Canvas, highScore: Int) {
+    fun drawIntro(canvas: Canvas, highScore: Int, semichos: Int, escapes: Int) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
 
         if (compact) {
@@ -86,7 +86,10 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
             canvas.drawText("Grab rugelach. ${Levels.all.size} levels to freedom.", w / 2, y, bodyPaint)
 
             if (highScore > 0) {
-                canvas.drawText("Best escape so far: $highScore", w / 2, h * 0.76f, bodyPaint)
+                canvas.drawText(
+                    "Best: $highScore · Semichos: $semichos/5 · Escapes: $escapes",
+                    w / 2, h * 0.76f, bodyPaint
+                )
             }
             canvas.drawText(confirmPrompt("start"), w / 2, h * 0.87f, accentPaint)
             return
@@ -112,8 +115,9 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
         canvas.drawText("${Levels.all.size} levels between you and freedom.", w / 2, y, bodyPaint); y += lh * 1.6f
 
         if (highScore > 0) {
-            canvas.drawText("Best escape so far: $highScore", w / 2, y, bodyPaint)
+            canvas.drawText("Best escape so far: $highScore", w / 2, y, bodyPaint); y += lh
         }
+        canvas.drawText("Semichos earned: $semichos/5 · Escapes: $escapes", w / 2, y, bodyPaint)
 
         canvas.drawText(confirmPrompt("start"), w / 2, h * 0.88f, accentPaint)
         canvas.drawText("Est. 5747 · Accredited by absolutely nobody", w / 2, h * 0.93f, finePrintPaint)


### PR DESCRIPTION
## What changed

- **Chalk fire**: from level 10 the Menahel lobs chalk in an arc at the talmid. A hit doesn't cost a life — it delivers mussar: half speed for two seconds with a gray cloud of rebuke overhead.
- **Semichos (achievements)**, persisted across launches: SEMICHA IN ESCAPOLOGY (finish all 18), FELAFEL SNIPER (25 lifetime stuns), ZRIZUS (level under 15s), KIBUD RUGELACH (every rugelach in one level), SHOMER NAFSHO (win without losing a hat). Earned ones get a long golden banner; the title screen shows the count plus lifetime escapes.
- **PA announcements**: the yeshiva intercom interrupts play at random with ten classics ("Reminder — the elevator is still fleishig.", "Supper is potato. Just potato.").

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_