### PR TITLE
Candy Man, chazaka combos, touch-control audit fixes, repo review

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -84,5 +84,6 @@ jobs:
           git config user.email "leaderboard-bot@users.noreply.github.com"
           git add leaderboard.json
           git commit -m "Record leaderboard score" || exit 0
+          # Retry once in case two submissions race
           git pull --rebase origin main
-          git push
+          git push || (git pull --rebase origin main && git push)

--- a/app/src/main/java/com/escapegame/GameView.kt
+++ b/app/src/main/java/com/escapegame/GameView.kt
@@ -35,6 +35,9 @@ class GameView(context: Context, private val engine: GameEngine) :
     // keypad devices: no shell, no on-screen controls, touches ignored.
     private val hasPhysicalDpad =
         resources.configuration.navigation == Configuration.NAVIGATION_DPAD
+    // Last control each finger was on, so sliding into the jump zones
+    // (rocking the d-pad up, or onto B) still triggers an edge jump
+    private val pointerControls = HashMap<Int, TouchGamepadLayout.Control>()
 
     init {
         holder.addCallback(this)
@@ -152,7 +155,10 @@ class GameView(context: Context, private val engine: GameEngine) :
                 }
                 MotionEvent.ACTION_MOVE -> refreshHeldControls(event, -1)
                 MotionEvent.ACTION_POINTER_UP -> refreshHeldControls(event, event.actionIndex)
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> releaseAllTouchControls()
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    pointerControls.clear()
+                    releaseAllTouchControls()
+                }
             }
         }
         return true
@@ -201,13 +207,30 @@ class GameView(context: Context, private val engine: GameEngine) :
 
     /** Recomputes all hold-style controls from the fingers still down. */
     private fun refreshHeldControls(event: MotionEvent, excludeIndex: Int) {
-        if (engine.phase != GamePhase.PLAYING) return
+        if (engine.phase != GamePhase.PLAYING) {
+            pointerControls.clear()
+            return
+        }
         var left = false
         var right = false
         var runHeld = false
         for (i in 0 until event.pointerCount) {
-            if (i == excludeIndex) continue
-            when (TouchGamepadLayout.hit(worldX(event, i), worldY(event, i))) {
+            val pointerId = event.getPointerId(i)
+            if (i == excludeIndex) {
+                pointerControls.remove(pointerId)
+                continue
+            }
+            val control = TouchGamepadLayout.hit(worldX(event, i), worldY(event, i))
+            // Sliding into a jump zone (d-pad rocked up, or onto B) counts
+            // as a fresh press
+            val previous = pointerControls.put(pointerId, control)
+            if (previous != null && previous != control &&
+                (control == TouchGamepadLayout.Control.DPAD_UP ||
+                    control == TouchGamepadLayout.Control.BUTTON_B)
+            ) {
+                engine.onJump()
+            }
+            when (control) {
                 TouchGamepadLayout.Control.DPAD_LEFT -> left = true
                 TouchGamepadLayout.Control.DPAD_RIGHT -> right = true
                 TouchGamepadLayout.Control.BUTTON_A -> runHeld = true

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -880,7 +880,9 @@ class GameEngine(
                 floatingTextPaint.color = t.color
                 canvas.drawText(t.text, t.x, t.y, floatingTextPaint)
             }
-            if (Modifier.DARK in level.modifiers && phase == GamePhase.PLAYING) {
+            if (Modifier.DARK in level.modifiers &&
+                (phase == GamePhase.PLAYING || phase == GamePhase.PAUSED)
+            ) {
                 // Everything outside the talmid's little circle of light
                 canvas.drawCircle(
                     talmid.centerX, talmid.centerY,

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
 import com.escapegame.core.GameConfig
+import com.escapegame.entities.CandyMan
 import com.escapegame.entities.Chalk
 import com.escapegame.entities.FelafelBall
 import com.escapegame.entities.Mashgiach
@@ -62,6 +63,8 @@ class GameEngine(
     private val platforms = mutableListOf<Platform>()
     private val felafelBalls = mutableListOf<FelafelBall>()
     private val chalks = mutableListOf<Chalk>()
+    private var candyMan: CandyMan? = null
+    private var candyManSpawnedThisLevel = false
     private val rugelach = mutableListOf<Rugelach>()
     private val powerUps = mutableListOf<PowerUp>()
     private val floatingTexts = mutableListOf<FloatingText>()
@@ -76,6 +79,9 @@ class GameEngine(
     private var vanFrames = -1
     private var chalkCooldown = 300
     private var runLivesLost = 0
+    // Chazaka: three quick rugelach start a x2 chain
+    private var comboCount = 0
+    private var comboFrames = 0
     // PA announcement state
     private var paCooldown = 1600
     private var paText: String? = null
@@ -291,8 +297,10 @@ class GameEngine(
                 }
             }
             GamePhase.PAUSED -> resumePlay()
-            GamePhase.GAME_OVER -> startNewGame()
-            GamePhase.VICTORY -> resetToIntro()
+            // Half-second debounce so a thumb still on the controls when a
+            // run ends can't skip these screens instantly
+            GamePhase.GAME_OVER -> if (phaseFrames > 30) startNewGame()
+            GamePhase.VICTORY -> if (phaseFrames > 30) resetToIntro()
         }
     }
 
@@ -432,6 +440,10 @@ class GameEngine(
             if (Modifier.SLIPPERY in level.modifiers) 0.975f else GameConfig.PLAYER_FRICTION
         talmid.windEnabled = Modifier.WIND in level.modifiers
         vanFrames = level.timeLimitSeconds?.times(60) ?: -1
+        candyMan = null
+        candyManSpawnedThisLevel = false
+        comboCount = 0
+        comboFrames = 0
         chalks.clear()
         chalkCooldown = 300 + Random.nextInt(180)
         paText = null
@@ -485,6 +497,11 @@ class GameEngine(
         }
 
         updateChalk()
+        updateCandyMan()
+        if (comboFrames > 0) {
+            comboFrames--
+            if (comboFrames == 0) comboCount = 0
+        }
         updateAnnouncements()
         updateFelafel()
         updatePickups()
@@ -518,6 +535,42 @@ class GameEngine(
                 music.playSfx(Sfx.STUN)
                 addFloatingText("GOT MUSSAR'D! Slowed!", talmid.centerX, talmid.y - 70f, Color.rgb(180, 60, 60))
                 iterator.remove()
+            }
+        }
+    }
+
+    /** Rarely, once per level, the Candy Man shuffles through with a treat. */
+    private fun updateCandyMan() {
+        val current = candyMan
+        if (current == null) {
+            if (!candyManSpawnedThisLevel && Random.nextInt(3200) == 0) {
+                candyManSpawnedThisLevel = true
+                candyMan = CandyMan(Random.nextBoolean(), worldWidth, floorTop)
+            }
+            return
+        }
+        current.update()
+        if (!current.active) {
+            candyMan = null
+            return
+        }
+        if (!current.collected &&
+            withinDistance(current.centerX, current.centerY, 60f)
+        ) {
+            current.collect()
+            music.playSfx(Sfx.POWERUP)
+            if (lives < 5) {
+                lives++
+                addFloatingText(
+                    "THE CANDY MAN! +1 hat!",
+                    current.centerX, current.y - 60f, Color.rgb(200, 60, 160)
+                )
+            } else {
+                addScore(300)
+                addFloatingText(
+                    "THE CANDY MAN! +300!",
+                    current.centerX, current.y - 60f, Color.rgb(200, 60, 160)
+                )
             }
         }
     }
@@ -591,9 +644,20 @@ class GameEngine(
             r.update()
             if (r.tryCollect(talmid.centerX, talmid.centerY, 60f)) {
                 music.playSfx(Sfx.PICKUP)
-                addScore(GameConfig.SCORE_RUGELACH)
+                comboCount++
+                comboFrames = 240
+                val chazaka = comboCount >= 3
+                val points =
+                    if (chazaka) GameConfig.SCORE_RUGELACH * 2 else GameConfig.SCORE_RUGELACH
+                addScore(points)
+                if (comboCount == 3) {
+                    addFloatingText(
+                        "CHAZAKA! Rugelach x2!",
+                        r.baseX, r.baseY - 55f, Color.rgb(255, 170, 40), 140
+                    )
+                }
                 addFloatingText(
-                    "+${GameConfig.SCORE_RUGELACH}",
+                    "+$points",
                     r.baseX, r.baseY - 30f, Color.rgb(60, 140, 40)
                 )
             }
@@ -811,6 +875,7 @@ class GameEngine(
             talmid.draw(canvas)
             for (ball in felafelBalls) ball.draw(canvas)
             for (chalk in chalks) chalk.draw(canvas)
+            candyMan?.draw(canvas)
             for (t in floatingTexts) {
                 floatingTextPaint.color = t.color
                 canvas.drawText(t.text, t.x, t.y, floatingTextPaint)

--- a/app/src/main/java/com/escapegame/entities/CandyMan.kt
+++ b/app/src/main/java/com/escapegame/entities/CandyMan.kt
@@ -1,0 +1,94 @@
+package com.escapegame.entities
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+
+/**
+ * The Candy Man, out of retirement for one day only. Shuffles across the
+ * floor with his little bag; reach him before he leaves and he'll slip you
+ * a sucking candy (an extra hat, or points if you're already at five).
+ * He does not run. He has never run. He doesn't need to.
+ */
+class CandyMan(
+    startLeft: Boolean,
+    private val worldWidth: Float,
+    floorTopY: Float
+) {
+    var x = if (startLeft) -60f else worldWidth + 10f
+        private set
+    val y = floorTopY - HEIGHT
+
+    private val direction = if (startLeft) 1f else -1f
+    var active = true
+        private set
+    var collected = false
+        private set
+
+    val centerX: Float get() = x + WIDTH / 2
+    val centerY: Float get() = y + HEIGHT / 2
+
+    private var animFrame = 0
+
+    private val coatPaint = Paint().apply { color = Color.rgb(90, 65, 45); style = Paint.Style.FILL }
+    private val shirtPaint = Paint().apply { color = Color.WHITE; style = Paint.Style.FILL }
+    private val headPaint = Paint().apply { color = Color.rgb(255, 220, 177); style = Paint.Style.FILL }
+    private val hatPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL }
+    private val beardPaint = Paint().apply { color = Color.WHITE; style = Paint.Style.FILL }
+    private val bagPaint = Paint().apply { color = Color.rgb(180, 40, 40); style = Paint.Style.FILL }
+    private val candyPaint = Paint().apply { color = Color.rgb(240, 200, 60); style = Paint.Style.FILL }
+    private val detailPaint = Paint().apply {
+        color = Color.BLACK
+        strokeWidth = 2f
+        style = Paint.Style.STROKE
+    }
+    private val labelPaint = Paint().apply {
+        color = Color.rgb(120, 60, 20)
+        textSize = 18f
+        textAlign = Paint.Align.CENTER
+    }
+
+    /** Marks the candy as taken; he keeps shuffling on, mission accomplished. */
+    fun collect() {
+        collected = true
+    }
+
+    fun update() {
+        if (!active) return
+        animFrame++
+        x += direction * SPEED
+        if (x < -80f || x > worldWidth + 80f) active = false
+    }
+
+    fun draw(canvas: Canvas) {
+        if (!active) return
+        val s = WIDTH
+        val bob = if ((animFrame / 20) % 2 == 0) 0f else 2f
+
+        // Long coat
+        canvas.drawRect(x + 5, y + 18 + bob, x + s - 5, y + HEIGHT + bob, coatPaint)
+        canvas.drawRect(x + 16, y + 18 + bob, x + s - 16, y + 30 + bob, shirtPaint)
+        // Head, hat, big friendly beard
+        canvas.drawOval(x + 9, y - 24 + bob, x + s - 9, y + 16 + bob, headPaint)
+        canvas.drawOval(x + 3, y - 28 + bob, x + s - 3, y - 18 + bob, hatPaint)
+        canvas.drawOval(x + 9, y - 36 + bob, x + s - 9, y - 20 + bob, hatPaint)
+        canvas.drawOval(x + s / 4, y - 2 + bob, x + 3 * s / 4, y + 22 + bob, beardPaint)
+        // Smiling eyes (the only non-stern eyes in this yeshiva)
+        canvas.drawLine(x + s / 2 - 12, y - 10 + bob, x + s / 2 - 4, y - 13 + bob, detailPaint)
+        canvas.drawLine(x + s / 2 + 4, y - 13 + bob, x + s / 2 + 12, y - 10 + bob, detailPaint)
+        // The famous candy bag
+        val bagX = if (direction > 0) x + s - 2 else x - 24
+        canvas.drawOval(bagX, y + 34 + bob, bagX + 26, y + 64 + bob, bagPaint)
+        if (!collected) {
+            canvas.drawCircle(bagX + 13, y + 30 + bob, 7f, candyPaint)
+        }
+
+        canvas.drawText("CANDY MAN", x + s / 2, y + HEIGHT + 20, labelPaint)
+    }
+
+    private companion object {
+        const val WIDTH = 52f
+        const val HEIGHT = 70f
+        const val SPEED = 2f
+    }
+}

--- a/app/src/main/java/com/escapegame/levels/Levels.kt
+++ b/app/src/main/java/com/escapegame/levels/Levels.kt
@@ -543,7 +543,11 @@ object Levels {
         "Not in MY yeshiva!",
         "Who gave you a heter?!",
         "That felafel comes out of recess!",
-        "I know your chavrusa's father!"
+        "I know your chavrusa's father!",
+        "We have a SHIDDUCH to think about!",
+        "Is that a CHAZAKA?! Assur!",
+        "The Candy Man can't save you!",
+        "You'll be shoveling the eruv path for this!"
     )
 
     /** Random headline for the game-over screen. */
@@ -651,7 +655,10 @@ object Levels {
         "PA: Reminder - the elevator is still fleishig.",
         "PA: The Menahel requests you stop running. Immediately.",
         "PA: Supper is potato. Just potato.",
-        "PA: The coffee room is closed for chometz. It is Cheshvan."
+        "PA: The coffee room is closed for chometz. It is Cheshvan.",
+        "PA: The Candy Man was spotted. This is not a drill.",
+        "PA: Whoever is playing music in the beis medrash - nice niggun.",
+        "PA: Tonight's shiur: 'Running: A Halachic Analysis.'"
     )
 
     /** Lines for the victory screen, in display order. */

--- a/app/src/main/java/com/escapegame/render/TouchGamepad.kt
+++ b/app/src/main/java/com/escapegame/render/TouchGamepad.kt
@@ -153,6 +153,7 @@ class TouchGamepadRenderer {
         drawArrow(canvas, cx - arm + 32f, cy, -1f, 0f)
         drawArrow(canvas, cx + arm - 32f, cy, 1f, 0f)
         drawArrow(canvas, cx, cy - arm + 32f, 0f, -1f)
+        drawArrow(canvas, cx, cy + arm - 32f, 0f, 1f)
 
         // B then A (A overlaps on top, like the real thing)
         canvas.drawCircle(TouchGamepadLayout.B_CX, TouchGamepadLayout.B_CY, TouchGamepadLayout.BUTTON_RADIUS, buttonPaint)


### PR DESCRIPTION
## What changed

### New gameplay
- **The Candy Man** — a rare, once-per-level friendly NPC who shuffles across the floor with his bag; reach him for an extra hat (or +300 points at five hats). He does not run. He has never needed to.
- **Chazaka combo** — three rugelach within four seconds start a ×2 chain, announced with a CHAZAKA banner; the chain holds while pickups keep coming.
- More Menahel quotes and PA announcements ("PA: The Candy Man was spotted. This is not a drill.")

### Touch-control audit (full function + design review)
- **Rock-to-jump**: sliding a finger from LEFT/RIGHT into the d-pad's UP zone (or onto B) now edge-triggers a jump via per-pointer control tracking — previously only a fresh finger-down jumped.
- **End-screen debounce**: game-over/victory ignore confirm for half a second so a thumb still on the controls can't skip them.
- The d-pad now draws all four arrows.
- Verified geometry (no overlapping hit zones), coordinate transforms (shell space for controls, LCD-inverse for menu taps), multi-touch hold recomputation, and the pause/resume finger lifecycle.

### Leaderboard reachability (verified both device types)
- Keypad/d-pad: `7` or `DOWN` on the title screen (printed on screen).
- Touch: the SELECT pill on the title screen, routed before the generic tap-confirm.

### Repo-wide review fixes
- DARK-modifier darkness now persists while paused (no free peek at the level).
- The leaderboard workflow retries its push once if two submissions race.

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_