### PR TITLE
Fix touch d-pad DOWN in menus; make the leaderboard entrance obvious

### DIFF
--- a/app/src/main/java/com/escapegame/GameView.kt
+++ b/app/src/main/java/com/escapegame/GameView.kt
@@ -185,6 +185,7 @@ class GameView(context: Context, private val engine: GameEngine) :
                 TouchGamepadLayout.Control.DPAD_RIGHT -> {
                     engine.onRight(true); engine.onRight(false)
                 }
+                TouchGamepadLayout.Control.DPAD_DOWN,
                 TouchGamepadLayout.Control.BUTTON_B -> engine.onMenuDown()
                 // A and START confirm the current selection
                 TouchGamepadLayout.Control.BUTTON_A,
@@ -211,6 +212,8 @@ class GameView(context: Context, private val engine: GameEngine) :
             // Overlay screens: taps confirm, EXCEPT on the d-pad or B - a
             // thumb resting on movement controls must never skip a screen
             when (control) {
+                // DOWN mirrors the keypad: leaderboard from the title screen
+                TouchGamepadLayout.Control.DPAD_DOWN -> engine.onMenuDown()
                 TouchGamepadLayout.Control.DPAD_LEFT,
                 TouchGamepadLayout.Control.DPAD_RIGHT,
                 TouchGamepadLayout.Control.DPAD_UP,

--- a/app/src/main/java/com/escapegame/GameView.kt
+++ b/app/src/main/java/com/escapegame/GameView.kt
@@ -218,7 +218,24 @@ class GameView(context: Context, private val engine: GameEngine) :
                 TouchGamepadLayout.Control.DPAD_RIGHT,
                 TouchGamepadLayout.Control.DPAD_UP,
                 TouchGamepadLayout.Control.BUTTON_B -> Unit
-                else -> engine.onActionDown()
+                else -> {
+                    if (engine.phase == GamePhase.INTRO) {
+                        // Title-screen taps are position-sensitive (the
+                        // leaderboard button), so convert to world coords
+                        val shellX = worldX(event, pointerIndex)
+                        val shellY = worldY(event, pointerIndex)
+                        if (touchMode) {
+                            engine.onIntroTap(
+                                (shellX - TouchGamepadLayout.screenOffsetX) / TouchGamepadLayout.screenScale,
+                                (shellY - TouchGamepadLayout.screenOffsetY) / TouchGamepadLayout.screenScale
+                            )
+                        } else {
+                            engine.onIntroTap(shellX, shellY)
+                        }
+                    } else {
+                        engine.onActionDown()
+                    }
+                }
             }
             return
         }

--- a/app/src/main/java/com/escapegame/engine/GameEngine.kt
+++ b/app/src/main/java/com/escapegame/engine/GameEngine.kt
@@ -253,6 +253,19 @@ class GameEngine(
     }
 
     /**
+     * A tap on the title screen (world coordinates): the leaderboard button
+     * opens the board, anywhere else starts the game.
+     */
+    fun onIntroTap(x: Float, y: Float) {
+        if (phase != GamePhase.INTRO) return
+        if (overlay.leaderboardButtonAt(x, y)) {
+            onLeaderboardKey()
+        } else {
+            onActionDown()
+        }
+    }
+
+    /**
      * A tap on a menu screen (world coordinates). Only a tap that actually
      * lands on a row selects and confirms it — misses do nothing, so stray
      * taps (e.g. on the shell) can't skip a menu.

--- a/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
+++ b/app/src/main/java/com/escapegame/render/OverlayRenderer.kt
@@ -94,6 +94,32 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
     }
     private val cardRect = RectF()
 
+    /** The tappable GLOBAL LEADERBOARD button on the title screen. */
+    private val leaderboardButtonRect = RectF()
+
+    init {
+        if (compact) {
+            leaderboardButtonRect.set(w * 0.24f, h * 0.905f, w * 0.76f, h * 0.968f)
+        } else {
+            leaderboardButtonRect.set(w * 0.18f, h * 0.895f, w * 0.82f, h * 0.952f)
+        }
+    }
+
+    /** True if the point is on the title screen's leaderboard button. */
+    fun leaderboardButtonAt(x: Float, y: Float): Boolean =
+        leaderboardButtonRect.contains(x, y)
+
+    private fun drawLeaderboardButton(canvas: Canvas, label: String) {
+        canvas.drawRoundRect(leaderboardButtonRect, 16f, 16f, cardPaint)
+        canvas.drawRoundRect(leaderboardButtonRect, 16f, 16f, cardStrokePaint)
+        canvas.drawText(
+            label,
+            leaderboardButtonRect.centerX(),
+            leaderboardButtonRect.centerY() + 11f,
+            accentPaint
+        )
+    }
+
     fun drawIntro(canvas: Canvas, highScore: Int, semichos: Int, escapes: Int) {
         canvas.drawRect(0f, 0f, w, h, dimPaint)
 
@@ -115,6 +141,7 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
                 )
             }
             canvas.drawText(confirmPrompt("start"), w / 2, h * 0.87f, accentPaint)
+            drawLeaderboardButton(canvas, "GLOBAL LEADERBOARD — TAP HERE")
             return
         }
 
@@ -142,8 +169,9 @@ class OverlayRenderer(private val w: Float, private val h: Float) {
         }
         canvas.drawText("Semichos earned: $semichos/5 · Escapes: $escapes", w / 2, y, bodyPaint)
 
-        canvas.drawText(confirmPrompt("start"), w / 2, h * 0.88f, accentPaint)
-        canvas.drawText("Est. 5747 · Accredited by absolutely nobody", w / 2, h * 0.93f, finePrintPaint)
+        canvas.drawText(confirmPrompt("start"), w / 2, h * 0.87f, accentPaint)
+        drawLeaderboardButton(canvas, "7 / DOWN — GLOBAL LEADERBOARD")
+        canvas.drawText("Est. 5747 · Accredited by absolutely nobody", w / 2, h * 0.978f, finePrintPaint)
     }
 
     fun drawDifficultySelect(canvas: Canvas, selected: Int) {

--- a/app/src/main/java/com/escapegame/render/TouchGamepad.kt
+++ b/app/src/main/java/com/escapegame/render/TouchGamepad.kt
@@ -18,7 +18,7 @@ import com.escapegame.core.GameConfig
  */
 object TouchGamepadLayout {
 
-    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, BUTTON_A, BUTTON_B, START, SELECT, MUTE, NONE }
+    enum class Control { DPAD_LEFT, DPAD_RIGHT, DPAD_UP, DPAD_DOWN, BUTTON_A, BUTTON_B, START, SELECT, MUTE, NONE }
 
     // Shell geometry: a wide, minimal bezel around a 4:3 landscape LCD;
     // the game world (1440x1080) fits it exactly.
@@ -75,7 +75,7 @@ object TouchGamepadLayout {
             return if (kotlin.math.abs(dx) > kotlin.math.abs(dy)) {
                 if (dx < 0) Control.DPAD_LEFT else Control.DPAD_RIGHT
             } else {
-                if (dy < 0) Control.DPAD_UP else Control.NONE // down is unused
+                if (dy < 0) Control.DPAD_UP else Control.DPAD_DOWN
             }
         }
         return Control.NONE


### PR DESCRIPTION
## Fixes only

### Touch d-pad DOWN didn't work in menus
The cross's down arm was mapped to `NONE` ("down is unused"). `DPAD_DOWN` is now a real control: navigates down in menus, opens the leaderboard from the title screen (matching keypad DOWN), and stays inert during gameplay and on other overlays.

### "I still don't get how to view the leaderboard"
The entry point was a buried text line. The title screen now shows a bordered **GLOBAL LEADERBOARD** button:
- **Touch**: the button itself is tappable (taps converted to world coordinates and hit-tested); SELECT and d-pad DOWN also work.
- **Keypad**: labeled "7 / DOWN — GLOBAL LEADERBOARD".

Verified by CI: build green, release APK artifact produced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_