### PR TITLE
Publish a GitHub Release with the APK on version tags

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build release APK
@@ -36,3 +39,12 @@ jobs:
           name: escape-your-menahel-release
           path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
+
+      # Pushing a tag (e.g. v2.0.0) publishes a GitHub Release with the APK
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Escape Your Menahel ${{ github.ref_name }}
+          files: app/build/outputs/apk/release/app-release.apk
+          generate_release_notes: true


### PR DESCRIPTION
Pushing a `v*` tag now publishes a GitHub Release named "Escape Your Menahel <tag>" with the release APK attached and auto-generated notes. Regular branch pushes keep uploading the CI artifact as before.

Verified by CI: build green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfo58DcqfLf7sekKUwdRV)_